### PR TITLE
Adjust stepper value alignment

### DIFF
--- a/StudyGroupApp/LifeScoreboardView.swift
+++ b/StudyGroupApp/LifeScoreboardView.swift
@@ -57,8 +57,10 @@ private struct IntStepperRow: View {
             Text(label)
             Spacer()
             Text("\(value)")
-                .frame(width: 40, alignment: .trailing)
+                .monospacedDigit()
+                .frame(width: 30, alignment: .trailing)
             Stepper("", value: $value, in: 0...1000)
+                .labelsHidden()
         }
         .frame(maxWidth: .infinity)
     }


### PR DESCRIPTION
## Summary
- tweak IntStepperRow layout so numbers sit just left of the Stepper

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68446dd1f8f88322badfc6acb47dcc37