### PR TITLE
Fix unterminated string literal

### DIFF
--- a/StudyGroupApp/LifeScoreboardViewModel.swift
+++ b/StudyGroupApp/LifeScoreboardViewModel.swift
@@ -45,7 +45,7 @@ class LifeScoreboardViewModel: ObservableObject {
         container.publicCloudDatabase.perform(query, inZoneWith: nil) { records, error in
             DispatchQueue.main.async {
                 guard let records = records else {
-                    print("❌ Load error: \(error?.localizedDescription ?? \"Unknown error\")")
+                    print("❌ Load error: \(error?.localizedDescription ?? "Unknown error")")
                     return
                 }
 


### PR DESCRIPTION
## Summary
- fix string interpolation in `LifeScoreboardViewModel` load method

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68447c48f3708322b628cf6604364b1c