### PR TITLE
Fix CloudKit load/save for scoreboard

### DIFF
--- a/StudyGroupApp/LifeScoreboardViewModel.swift
+++ b/StudyGroupApp/LifeScoreboardViewModel.swift
@@ -1,5 +1,5 @@
 import CloudKit
-import SwiftUI
+import Foundation
 
 class LifeScoreboardViewModel: ObservableObject {
     @Published var scores: [ScoreEntry] = []
@@ -8,7 +8,7 @@ class LifeScoreboardViewModel: ObservableObject {
     @Published var travel: Double = 31.0
 
     private let container = CKContainer.default()
-    private let recordType = "LifeScoreEntry"
+    private let recordType = "ScoreRecord"
 
     struct ScoreEntry: Identifiable, Hashable {
         var id = UUID()
@@ -74,10 +74,10 @@ class LifeScoreboardViewModel: ObservableObject {
             DispatchQueue.main.async {
                 self.scores = loadedEntries
                 self.activity = loadedActivity
+                print("✅ Loaded \(loadedEntries.count) scores from CloudKit")
             }
         }
     }
-        }
     func save(_ entry: ScoreEntry, pending: Int, projected: Double) {
         guard let index = scores.firstIndex(where: { $0.name == entry.name }) else { return }
         scores[index].score = entry.score


### PR DESCRIPTION
## Summary
- fix scoreboard record type
- streamline CloudKit load logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844822938b48322b78947b5a9399041