### PR TITLE
Refactor scoreboard CloudKit logic

### DIFF
--- a/CloudKitManager.swift
+++ b/CloudKitManager.swift
@@ -243,7 +243,7 @@ class CloudKitManager: ObservableObject {
     func saveScore(entry: LifeScoreboardViewModel.ScoreEntry, pending: Int, projected: Double) {
         let predicate = NSPredicate(format: "name == %@", entry.name)
         let query = CKQuery(recordType: scoreRecordType, predicate: predicate)
-        database.perform(query, inZoneWith: nil) { records, error in
+        database.perform(query, inZoneWith: nil) { records, _ in
             let record = records?.first ?? CKRecord(recordType: self.scoreRecordType)
             record["name"] = entry.name as CKRecordValue
             record["score"] = entry.score as CKRecordValue
@@ -251,11 +251,82 @@ class CloudKitManager: ObservableObject {
             record["projected"] = projected as CKRecordValue
             self.database.save(record) { _, error in
                 if let error = error {
-                    print("❌ Error saving score: \(error.localizedDescription)\")
+                    print("❌ Error saving score: \(error.localizedDescription)")
                 } else {
                     print("✅ Saved score for \(entry.name)")
                 }
             }
         }
+    }
+
+    func createScoreRecord(for name: String) {
+        let record = CKRecord(recordType: scoreRecordType)
+        record["name"] = name as CKRecordValue
+        record["score"] = 0 as CKRecordValue
+        record["pending"] = 0 as CKRecordValue
+        record["projected"] = 0.0 as CKRecordValue
+        database.save(record) { _, error in
+            if let error = error {
+                print("❌ Error creating score record: \(error.localizedDescription)")
+            } else {
+                print("✅ Created score record for \(name)")
+            }
+        }
+    }
+
+    func deleteScoreRecord(for name: String) {
+        let predicate = NSPredicate(format: "name == %@", name)
+        let query = CKQuery(recordType: scoreRecordType, predicate: predicate)
+        let operation = CKQueryOperation(query: query)
+        operation.resultsLimit = 1
+
+        var matchedID: CKRecord.ID?
+        operation.recordMatchedBlock = { recordID, result in
+            if case .success = result {
+                matchedID = recordID
+            }
+        }
+
+        operation.queryResultBlock = { [weak self] _ in
+            guard let self = self, let id = matchedID else { return }
+            self.database.delete(withRecordID: id) { _, error in
+                if let error = error {
+                    print("❌ Error deleting score record: \(error.localizedDescription)")
+                } else {
+                    print("🗑️ Deleted score record for \(name)")
+                }
+            }
+        }
+
+        database.add(operation)
+    }
+
+    func fetchScores(for names: [String], completion: @escaping ([String: (score: Int, pending: Int, projected: Double)]) -> Void) {
+        guard !names.isEmpty else {
+            completion([:])
+            return
+        }
+        let predicate = NSPredicate(format: "name IN %@", names)
+        let query = CKQuery(recordType: scoreRecordType, predicate: predicate)
+
+        var results: [String: (Int, Int, Double)] = [:]
+        let operation = CKQueryOperation(query: query)
+        operation.recordMatchedBlock = { _, result in
+            if case .success(let record) = result {
+                let name = record["name"] as? String ?? ""
+                let score = record["score"] as? Int ?? 0
+                let pending = record["pending"] as? Int ?? 0
+                let projected = record["projected"] as? Double ?? 0.0
+                results[name] = (score, pending, projected)
+            }
+        }
+
+        operation.queryResultBlock = { _ in
+            DispatchQueue.main.async {
+                completion(results)
+            }
+        }
+
+        database.add(operation)
     }
 }

--- a/StudyGroupApp/LifeScoreboardView.swift
+++ b/StudyGroupApp/LifeScoreboardView.swift
@@ -135,10 +135,14 @@ struct LifeScoreboardView: View {
             .padding()
         }
         .onAppear {
-            viewModel.load()
+            viewModel.load(for: userManager.allUsers)
+        }
+        .onReceive(userManager.$allUsers) { names in
+            viewModel.load(for: names)
         }
         .refreshable {
             userManager.refresh()
+            viewModel.load(for: userManager.allUsers)
         }
         .background(
             LinearGradient(

--- a/StudyGroupApp/LifeScoreboardViewModel.swift
+++ b/StudyGroupApp/LifeScoreboardViewModel.swift
@@ -46,35 +46,30 @@ class LifeScoreboardViewModel: ObservableObject {
         activity.first(where: { $0.name == name })
     }
 
-    func load() {
-        print("🔄 Fetching from CloudKit...")
-        let query = CKQuery(recordType: recordType, predicate: NSPredicate(value: true))
-        container.publicCloudDatabase.perform(query, inZoneWith: nil) { records, error in
-            guard let records = records else {
-                DispatchQueue.main.async {
-                    print("❌ Load error: \(error?.localizedDescription ?? \"Unknown error\")")
+    private func updateLocalEntries(names: [String]) {
+        // Remove entries for deleted users
+        scores.removeAll { entry in !names.contains(entry.name) }
+        activity.removeAll { row in !names.contains(row.name) }
+
+        // Add entries for new users
+        for name in names where !scores.contains(where: { $0.name == name }) {
+            let entry = ScoreEntry(name: name, score: 0)
+            scores.append(entry)
+            activity.append(ActivityRow(entry: entry))
+        }
+    }
+
+    func load(for names: [String]) {
+        updateLocalEntries(names: names)
+        CloudKitManager.shared.fetchScores(for: names) { records in
+            for (name, values) in records {
+                if let index = self.scores.firstIndex(where: { $0.name == name }) {
+                    self.scores[index].score = values.score
                 }
-                return
-            }
-
-            let loadedEntries = records.map { record -> ScoreEntry in
-                ScoreEntry(
-                    name: record["name"] as? String ?? "",
-                    score: record["score"] as? Int ?? 0
-                )
-            }
-            let loadedActivity = records.map { record -> ActivityRow in
-                ActivityRow(
-                    name: record["name"] as? String ?? "",
-                    pending: record["pending"] as? Int ?? 0,
-                    projected: record["projected"] as? Double ?? 0.0
-                )
-            }
-
-            DispatchQueue.main.async {
-                self.scores = loadedEntries
-                self.activity = loadedActivity
-                print("✅ Loaded \(loadedEntries.count) scores from CloudKit")
+                if let row = self.activity.first(where: { $0.name == name }) {
+                    row.pending = values.pending
+                    row.projected = values.projected
+                }
             }
         }
     }

--- a/StudyGroupApp/UserManager.swift
+++ b/StudyGroupApp/UserManager.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CloudKit
 
 class UserManager: ObservableObject {
     static let shared = UserManager()
@@ -11,19 +10,31 @@ class UserManager: ObservableObject {
         }
     }
 
-    private let cloudKit = CloudKitManager()
+    private let userDefaultsKey = "allUsers"
+
     private init() {
         self.currentUserName = UserDefaults.standard.string(forKey: "selectedUserName") ?? ""
-        loadUsers()
+        if let stored = UserDefaults.standard.array(forKey: userDefaultsKey) as? [String] {
+            self.allUsers = stored
+        } else {
+            self.allUsers = ["D.J.", "Ron", "Deanna", "Dimitri"]
+            saveUsers()
+        }
     }
 
-    func loadUsers() {
-        cloudKit.fetchTeam { members in
-            let names = members.map { $0.name }.sorted()
-            DispatchQueue.main.async {
-                self.allUsers = names
-            }
-        }
+    private func saveUsers() {
+        UserDefaults.standard.set(allUsers, forKey: userDefaultsKey)
+    }
+
+    func addUser(_ name: String) {
+        guard !allUsers.contains(name) else { return }
+        allUsers.append(name)
+        saveUsers()
+    }
+
+    func deleteUser(_ name: String) {
+        allUsers.removeAll { $0 == name }
+        saveUsers()
     }
 
     func selectUser(_ name: String) {
@@ -31,6 +42,6 @@ class UserManager: ObservableObject {
     }
 
     func refresh() {
-        loadUsers()
+        allUsers = UserDefaults.standard.array(forKey: userDefaultsKey) as? [String] ?? []
     }
 }


### PR DESCRIPTION
## Summary
- store user list locally in `UserManager`
- manage names locally in `UserSelectorView` and create/delete matching CloudKit score records
- sync scoreboard values only using `ScoreRecord` via new `CloudKitManager` helpers
- update `LifeScoreboardViewModel` to load data for local users and update instantly
- refresh `LifeScoreboardView` when the user list changes

## Testing
- `swiftc -parse StudyGroupApp/UserManager.swift StudyGroupApp/LifeScoreboardViewModel.swift StudyGroupApp/UserSelectorView.swift StudyGroupApp/LifeScoreboardView.swift`
- `find StudyGroupApp -name '*.swift' | xargs swiftc -parse`

------
https://chatgpt.com/codex/tasks/task_e_68448a9757bc8322b19d6aa57db49f72