### PR TITLE
Sync user selection across views

### DIFF
--- a/StudyGroupApp/LifeScoreboardView.swift
+++ b/StudyGroupApp/LifeScoreboardView.swift
@@ -135,14 +135,14 @@ struct LifeScoreboardView: View {
             .padding()
         }
         .onAppear {
-            viewModel.load(for: userManager.allUsers)
+            viewModel.load(for: userManager.userList)
         }
-        .onReceive(userManager.$allUsers) { names in
+        .onReceive(userManager.$userList) { names in
             viewModel.load(for: names)
         }
         .refreshable {
             userManager.refresh()
-            viewModel.load(for: userManager.allUsers)
+            viewModel.load(for: userManager.userList)
         }
         .background(
             LinearGradient(
@@ -254,7 +254,7 @@ private struct TeamMembersCard: View {
     }
 
     var body: some View {
-        let sortedNames = userManager.allUsers.sorted { lhs, rhs in
+        let sortedNames = userManager.userList.sorted { lhs, rhs in
             viewModel.score(for: lhs) > viewModel.score(for: rhs)
         }
 
@@ -270,7 +270,7 @@ private struct TeamMembersCard: View {
                         TeamMemberRow(
                             entry: entry,
                             color: color(for: Double(entry.score)),
-                            isCurrentUser: name == userManager.currentUserName
+                            isCurrentUser: name == userManager.currentUser
                         ) {
                             onSelect(entry, row)
                         }
@@ -317,7 +317,7 @@ private struct ActivityCard: View {
     var onSelect: (LifeScoreboardViewModel.ScoreEntry, LifeScoreboardViewModel.ActivityRow) -> Void
 
     var body: some View {
-        let sortedRows = userManager.allUsers
+        let sortedRows = userManager.userList
             .compactMap { viewModel.row(for: $0) }
             .sorted { $0.projected > $1.projected }
 
@@ -340,7 +340,7 @@ private struct ActivityCard: View {
                 }
 
                 ForEach(sortedRows) { row in
-                    let isCurrent = row.name == userManager.currentUserName
+                    let isCurrent = row.name == userManager.currentUser
                     ActivityRowView(row: row, isCurrentUser: isCurrent) {
                         if let entry = viewModel.scores.first(where: { $0.name == row.name }) {
                             onSelect(entry, row)

--- a/StudyGroupApp/MainTabView.swift
+++ b/StudyGroupApp/MainTabView.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 
 struct MainTabView: View {
+    @EnvironmentObject var userManager: UserManager
     init() {
         UITabBar.appearance().backgroundColor = UIColor.systemGray6
     }

--- a/StudyGroupApp/StudyGroupApp.swift
+++ b/StudyGroupApp/StudyGroupApp.swift
@@ -4,6 +4,7 @@ import SwiftUI
 @main
 struct StudyGroupApp: App {
     @State private var isShowingLaunchScreen = true
+    @StateObject private var userManager = UserManager.shared
 
     var body: some Scene {
         WindowGroup {
@@ -13,6 +14,7 @@ struct StudyGroupApp: App {
                         .transition(.opacity)
                 } else {
                     UserSelectorView()
+                        .environmentObject(userManager)
                         .transition(.opacity)
                 }
             }
@@ -24,6 +26,7 @@ struct StudyGroupApp: App {
                     }
                 }
             }
+            .environmentObject(userManager)
         }
     }
 }


### PR DESCRIPTION
## Summary
- use a shared `UserManager` observable object
- inject the manager into the app, splash screen, and main views
- update `WinTheDayView` to react to current user and user list changes
- keep Life Scoreboard logic intact while adopting new property names

## Testing
- `swiftc --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684493230c3483229b277b1b915fdaf1