### PR TITLE
Add full emoji picker and improve dark mode

### DIFF
--- a/Outcast/WinTheDayView.swift
+++ b/Outcast/WinTheDayView.swift
@@ -306,27 +306,45 @@ private var emojiPickerSheet: some View {
 }
 
 private var emojiGrid: some View {
-    let emojis = ["😀", "🎯", "🏆", "🎓", "💯", "🔥", "🎉", "💡", "📈", "📅"]
+    let emojis = [
+        "👨🏽‍🦲", "👨🏾‍🦲", "👨🏿‍🦲",
+        "😐", "🙂", "😊", "😌", "😎", "🤓",
+        "😏", "😶", "🙃", "😬", "🤔", "😯",
+        "🤨", "😄", "😅", "😇", "😍", "🤩",
+        "🏃🏽‍♀️", "🏃🏾‍♀️", "🏃🏿‍♀️",
+        "🏃🏽‍♂️", "🏃🏾‍♂️", "🏃🏿‍♂️",
+        "🧔🏽", "🧔🏾", "🧔🏿",
+        "👩🏽", "👩🏾", "👩🏿",
+        "🧑🏽", "🧑🏾", "🧑🏿",
+        "👨🏽", "👨🏾", "👨🏿",
+        "👩🏽‍🦱", "👩🏾‍🦱", "👩🏿‍🦱",
+        "👨🏽‍🦱", "👨🏾‍🦱", "👨🏿‍🦱",
+        "👦🏾", "👧🏾", "👴🏾",
+        "🤗", "🤝", "🫶🏾", "🙏🏾", "🤜🏾", "🤛🏾",
+        "😤", "😠", "😡", "🥹", "😢", "😭"
+    ]
+
+    let columns = Array(repeating: GridItem(.flexible()), count: 6)
+
     return ScrollView {
-        LazyVStack(alignment: .leading, spacing: 12) {
-            ForEach(emojis.chunked(into: 5), id: \.self) { row in
-                HStack {
-                    ForEach(row, id: \.self) { emoji in
-                        Button(action: {
-                            if let id = emojiEditingID,
-                               let index = viewModel.teamMembers.firstIndex(where: { $0.id == id }) {
-                                viewModel.teamMembers[index].emoji = emoji
-                                CloudKitManager().save(viewModel.teamMembers[index]) { _ in }
-                                viewModel.teamMembers = viewModel.teamMembers.map { $0 }
-                            }
-                            emojiPickerVisible = false
-                        }) {
-                            Text(emoji).font(.largeTitle)
-                        }
+        LazyVGrid(columns: columns, spacing: 12) {
+            ForEach(emojis, id: \.self) { emoji in
+                Button(action: {
+                    if let id = emojiEditingID,
+                       let index = viewModel.teamMembers.firstIndex(where: { $0.id == id }) {
+                        viewModel.teamMembers[index].emoji = emoji
+                        CloudKitManager().save(viewModel.teamMembers[index]) { _ in }
+                        viewModel.teamMembers = viewModel.teamMembers.map { $0 }
                     }
+                    emojiPickerVisible = false
+                }) {
+                    Text(emoji)
+                        .font(.system(size: 32))
+                        .frame(maxWidth: .infinity)
                 }
             }
         }
+        .padding(.vertical, 10)
     }
 }
 
@@ -454,7 +472,7 @@ struct StatRow: View {
 
             Text("\(value) / \(goal)")
                 .font(.subheadline.bold())
-                .foregroundColor(.black)
+                .foregroundColor(.primary)
                 .lineLimit(1)
                 .frame(width: 90, alignment: .trailing)
         }
@@ -573,7 +591,7 @@ private struct EditingOverlayView: View {
         }
         .padding()
         .frame(width: 280)
-        .background(Color.white)
+        .background(Color(uiColor: .systemBackground))
         .cornerRadius(12)
         .shadow(radius: 8)
         .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.gray.opacity(0.4)))
@@ -682,7 +700,7 @@ private struct TeamMemberCardView: View {
             )
         }
         .padding(6)
-        .background(Color.white)
+        .background(Color(uiColor: .secondarySystemBackground))
         .cornerRadius(12)
         .shadow(radius: 2)
         .frame(maxWidth: .infinity)

--- a/StudyGroupApp/LifeScoreboardView.swift
+++ b/StudyGroupApp/LifeScoreboardView.swift
@@ -43,7 +43,7 @@ struct ScoreboardEditorOverlay: View {
         }
         .padding()
         .frame(maxWidth: .infinity)
-        .background(Color.white)
+        .background(Color(uiColor: .systemBackground))
         .cornerRadius(12)
         .shadow(radius: 8)
         .padding(.horizontal)
@@ -199,7 +199,7 @@ private struct ScoreTile<Content: View>: View {
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 12)
-                .fill(Color.white)
+                .fill(Color(uiColor: .secondarySystemBackground))
                 .shadow(radius: 4)
 
             content()

--- a/StudyGroupApp/UserSelectorView.swift
+++ b/StudyGroupApp/UserSelectorView.swift
@@ -18,7 +18,7 @@ struct UserSelectorView: View {
     var body: some View {
         NavigationView {
             ZStack {
-                Color.white.ignoresSafeArea()
+                Color(.systemBackground).ignoresSafeArea()
 
                 GeometryReader { geometry in
                     VStack {

--- a/StudyGroupApp/WinTheDayView.swift
+++ b/StudyGroupApp/WinTheDayView.swift
@@ -392,27 +392,45 @@ private var emojiPickerSheet: some View {
 }
 
 private var emojiGrid: some View {
-    let emojis = ["😀", "🎯", "🏆", "🎓", "💯", "🔥", "🎉", "💡", "📈", "📅"]
+    let emojis = [
+        "👨🏽‍🦲", "👨🏾‍🦲", "👨🏿‍🦲",
+        "😐", "🙂", "😊", "😌", "😎", "🤓",
+        "😏", "😶", "🙃", "😬", "🤔", "😯",
+        "🤨", "😄", "😅", "😇", "😍", "🤩",
+        "🏃🏽‍♀️", "🏃🏾‍♀️", "🏃🏿‍♀️",
+        "🏃🏽‍♂️", "🏃🏾‍♂️", "🏃🏿‍♂️",
+        "🧔🏽", "🧔🏾", "🧔🏿",
+        "👩🏽", "👩🏾", "👩🏿",
+        "🧑🏽", "🧑🏾", "🧑🏿",
+        "👨🏽", "👨🏾", "👨🏿",
+        "👩🏽‍🦱", "👩🏾‍🦱", "👩🏿‍🦱",
+        "👨🏽‍🦱", "👨🏾‍🦱", "👨🏿‍🦱",
+        "👦🏾", "👧🏾", "👴🏾",
+        "🤗", "🤝", "🫶🏾", "🙏🏾", "🤜🏾", "🤛🏾",
+        "😤", "😠", "😡", "🥹", "😢", "😭"
+    ]
+
+    let columns = Array(repeating: GridItem(.flexible()), count: 6)
+
     return ScrollView {
-        LazyVStack(alignment: .leading, spacing: 12) {
-            ForEach(emojis.chunked(into: 5), id: \.self) { row in
-                HStack {
-                    ForEach(row, id: \.self) { emoji in
-                        Button(action: {
-                            if let id = emojiEditingID,
-                               let index = viewModel.teamMembers.firstIndex(where: { $0.id == id }) {
-                                viewModel.teamMembers[index].emoji = emoji
-                                viewModel.saveMember(viewModel.teamMembers[index])
-                                viewModel.teamMembers = viewModel.teamMembers.map { $0 }
-                            }
-                            emojiPickerVisible = false
-                        }) {
-                            Text(emoji).font(.largeTitle)
-                        }
+        LazyVGrid(columns: columns, spacing: 12) {
+            ForEach(emojis, id: \.self) { emoji in
+                Button(action: {
+                    if let id = emojiEditingID,
+                       let index = viewModel.teamMembers.firstIndex(where: { $0.id == id }) {
+                        viewModel.teamMembers[index].emoji = emoji
+                        viewModel.saveMember(viewModel.teamMembers[index])
+                        viewModel.teamMembers = viewModel.teamMembers.map { $0 }
                     }
+                    emojiPickerVisible = false
+                }) {
+                    Text(emoji)
+                        .font(.system(size: 32))
+                        .frame(maxWidth: .infinity)
                 }
             }
         }
+        .padding(.vertical, 10)
     }
 }
 
@@ -538,7 +556,7 @@ struct StatRow: View {
 
             Text("\(value) / \(goal)")
                 .font(.subheadline.bold())
-                .foregroundColor(.black)
+                .foregroundColor(.primary)
                 .lineLimit(1)
                 .frame(width: 90, alignment: .trailing)
         }
@@ -652,7 +670,7 @@ private struct EditingOverlayView: View {
         }
         .padding()
         .frame(width: 280)
-        .background(Color.white)
+        .background(Color(uiColor: .systemBackground))
         .cornerRadius(12)
         .shadow(radius: 8)
         .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.gray.opacity(0.4)))
@@ -766,7 +784,7 @@ private struct TeamMemberCardView: View {
             )
         }
         .padding(6)
-        .background(Color.white)
+        .background(Color(uiColor: .secondarySystemBackground))
         .cornerRadius(12)
         .shadow(radius: 2)
         .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Summary
- provide a large emoji selection for Win The Day
- tweak card backgrounds and overlay colors to respect dark mode
- adjust scoreboard colors to adapt to system light/dark appearance
- update splash screen background to system color

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68449df82e248322a4f83a4293dcb83a