### PR TITLE
Adjust Activity table layout

### DIFF
--- a/StudyGroupApp/LifeScoreboardView.swift
+++ b/StudyGroupApp/LifeScoreboardView.swift
@@ -333,10 +333,10 @@ private struct ActivityCard: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                     Text("Pending")
                         .font(.system(size: 16, weight: .bold))
-                        .frame(width: 70, alignment: .center)
+                        .frame(width: 60, alignment: .center)
                     Text("Projected")
-                        .font(.system(size: 16, weight: .bold))
-                        .frame(minWidth: 100, alignment: .trailing)
+                        .font(.system(size: 17, weight: .bold))
+                        .frame(minWidth: 110, alignment: .trailing)
                 }
 
                 ForEach(sortedRows) { row in
@@ -367,12 +367,12 @@ private struct ActivityRowView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             Text("\(row.pending)")
                 .font(.system(size: 15, weight: .regular))
-                .frame(width: 70, alignment: .center)
+                .frame(width: 60, alignment: .center)
                 .monospacedDigit()
-            Text(row.projected, format: .currency(code: "USD"))
-                .font(.system(size: 15, weight: .regular))
+            Text(row.projected, format: .currency(code: "USD").precision(.fractionLength(0)))
+                .font(.system(size: 17, weight: .regular))
                 .foregroundColor(.green)
-                .frame(minWidth: 100, alignment: .trailing)
+                .frame(minWidth: 110, alignment: .trailing)
                 .monospacedDigit()
         }
         .padding(.vertical, 6)


### PR DESCRIPTION
## Summary
- widen the Projected column and boost its font size
- tweak the Pending column width to keep alignment
- keep dollar formatting without decimals

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a2ca50108322a6aa96f63239ac4f