### PR TITLE
Fix alignment in team progress list

### DIFF
--- a/StudyGroupApp/LifeScoreboardView.swift
+++ b/StudyGroupApp/LifeScoreboardView.swift
@@ -299,6 +299,7 @@ private struct TeamMemberRow: View {
                     Image(systemName: "pencil")
                 }
             }
+            .frame(width: 100, alignment: .leading)
 
             ProgressView(value: Double(entry.score) / 100)
                 .tint(color)
@@ -308,6 +309,7 @@ private struct TeamMemberRow: View {
 
             Text("\(entry.score)")
                 .font(.system(size: 18, weight: .bold, design: .rounded))
+                .monospacedDigit()
                 .frame(width: 35, alignment: .trailing)
         }
         .padding(.vertical, 2)


### PR DESCRIPTION
## Summary
- align team member rows so the progress bars line up
- keep score digits in a fixed-width font

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844f32a26608322aea26e57597fde65