### PR TITLE
Fix team stat bar scaling

### DIFF
--- a/Outcast/WinTheDayView.swift
+++ b/Outcast/WinTheDayView.swift
@@ -464,7 +464,7 @@ struct StatRow: View {
                 Capsule()
                     .fill(progressColor(for: title, value: value, goal: goal))
                     .frame(
-                        width: goal > 0 ? min(CGFloat(value) / CGFloat(goal), 1.0) * 140 : 0,
+                        width: CGFloat(value) / 70 * 140,
                         height: 10
                     )
                     .padding(.leading, 10)

--- a/StudyGroupApp/WinTheDayView.swift
+++ b/StudyGroupApp/WinTheDayView.swift
@@ -548,7 +548,7 @@ struct StatRow: View {
                 Capsule()
                     .fill(progressColor(for: type, value: value, goal: goal))
                     .frame(
-                        width: goal > 0 ? min(CGFloat(value) / CGFloat(goal), 1.0) * 140 : 0,
+                        width: CGFloat(value) / 70 * 140,
                         height: 10
                     )
                     .padding(.leading, 10)


### PR DESCRIPTION
## Summary
- ensure team progress bars scale to a max of 70
- apply change in both iOS projects

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6845c250617c8322ba9956de9c4ae8de