### PR TITLE
Clamp StatRow progress

### DIFF
--- a/Outcast/WinTheDayView.swift
+++ b/Outcast/WinTheDayView.swift
@@ -464,7 +464,7 @@ struct StatRow: View {
                 Capsule()
                     .fill(progressColor(for: title, value: value, goal: goal))
                     .frame(
-                        width: CGFloat(value) / 70 * 140,
+                        width: min(CGFloat(value) / 70, 1.0) * 140,
                         height: 10
                     )
                     .padding(.leading, 10)

--- a/StudyGroupApp/WinTheDayView.swift
+++ b/StudyGroupApp/WinTheDayView.swift
@@ -548,7 +548,7 @@ struct StatRow: View {
                 Capsule()
                     .fill(progressColor(for: type, value: value, goal: goal))
                     .frame(
-                        width: CGFloat(value) / 70 * 140,
+                        width: min(CGFloat(value) / 70, 1.0) * 140,
                         height: 10
                     )
                     .padding(.leading, 10)


### PR DESCRIPTION
## Summary
- clamp progress width in StatRow progress bars

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845c5980dec83229490b95805aa25ac