### PR TITLE
Update fonts in LifeScoreboardView headers

### DIFF
--- a/StudyGroupApp/LifeScoreboardView.swift
+++ b/StudyGroupApp/LifeScoreboardView.swift
@@ -219,7 +219,7 @@ private struct OnTimeCard: View {
             HStack(alignment: .center) {
                 VStack(spacing: 2) {
                     Text("Honor")
-                        .font(.system(size: 17, weight: .semibold, design: .rounded))
+                        .font(.system(size: 20, weight: .bold))
                     ScoreBadge(text: String(format: "%.1f", onTime), color: .yellow)
                 }
 
@@ -352,18 +352,18 @@ private struct ActivityCard: View {
 
                 HStack(spacing: 6) {
                     Text("Name")
-                        .font(.system(size: 20, weight: .bold))
+                        .font(.system(size: 19, weight: .bold))
                         .monospacedDigit()
                         .frame(maxWidth: .infinity, alignment: .leading)
 
                     Text("Pending")
-                        .font(.system(size: 20, weight: .bold))
+                        .font(.system(size: 19, weight: .bold))
                         .monospacedDigit()
                         .frame(minWidth: 80, alignment: .center)
                         .lineLimit(1)
 
                     Text("Projected")
-                        .font(.system(size: 20, weight: .bold))
+                        .font(.system(size: 19, weight: .bold))
                         .monospacedDigit()
                         .frame(minWidth: 110, alignment: .trailing)
                 }


### PR DESCRIPTION
## Summary
- adjust `Honor` font in On Time card
- tweak header fonts in Activity card

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6845c73bc17c83228810db03af5bff81