### PR TITLE
Fix scoreboard and WinTheDay progress bars

### DIFF
--- a/Outcast/WinTheDayView.swift
+++ b/Outcast/WinTheDayView.swift
@@ -464,7 +464,7 @@ struct StatRow: View {
                 Capsule()
                     .fill(progressColor(for: title, value: value, goal: goal))
                     .frame(
-                        width: min(CGFloat(value) / 70, 1.0) * 140,
+                        width: min(CGFloat(value) / CGFloat(goal), 1.0) * 140,
                         height: 10
                     )
                     .padding(.leading, 10)

--- a/StudyGroupApp/LifeScoreboardView.swift
+++ b/StudyGroupApp/LifeScoreboardView.swift
@@ -312,8 +312,10 @@ private struct TeamMemberRow: View {
 
                     Capsule()
                         .fill(color)
-                        .frame(width: geo.size.width * CGFloat(entry.score) / 100,
-                               height: 8)
+                        .frame(
+                            width: min(CGFloat(entry.score) / 70, 1.0) * geo.size.width,
+                            height: 8
+                        )
                         .animation(.easeInOut(duration: 0.4), value: entry.score)
                 }
             }

--- a/StudyGroupApp/WinTheDayView.swift
+++ b/StudyGroupApp/WinTheDayView.swift
@@ -548,7 +548,7 @@ struct StatRow: View {
                 Capsule()
                     .fill(progressColor(for: type, value: value, goal: goal))
                     .frame(
-                        width: min(CGFloat(value) / 70, 1.0) * 140,
+                        width: min(CGFloat(value) / CGFloat(goal), 1.0) * 140,
                         height: 10
                     )
                     .padding(.leading, 10)


### PR DESCRIPTION
## Summary
- adjust team score progress bar to use a 70‑point scale
- restore Win the Day progress bars to use per-goal scaling

## Testing
- `swiftc -typecheck StudyGroupApp/LifeScoreboardView.swift StudyGroupApp/LifeScoreboardViewModel.swift StudyGroupApp/WinTheDayView.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_6845ca73e38c8322b55f3749a47f0b33