### PR TITLE
Remove pencil icon on Life Scoreboard rows

### DIFF
--- a/StudyGroupApp/LifeScoreboardView.swift
+++ b/StudyGroupApp/LifeScoreboardView.swift
@@ -294,13 +294,14 @@ private struct TeamMemberRow: View {
         HStack(spacing: 12) {
             HStack(spacing: 4) {
                 Text(entry.name)
-
-                    .font(.system(size: 19, weight: .regular, design: .rounded))
+                    .font(
+                        .system(
+                            size: 19,
+                            weight: isCurrentUser ? .bold : .regular,
+                            design: .rounded
+                        )
+                    )
                     .monospacedDigit()
-
-                if isCurrentUser {
-                    Image(systemName: "pencil")
-                }
             }
             .frame(width: 80, alignment: .leading)
 


### PR DESCRIPTION
## Summary
- remove the pencil icon from editable rows on the Life Scoreboard
- show editable status by bolding the current user's name

## Testing
- `xcodebuild -list -project StudyGroupApp/StudyGroupApp.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f193128c8322ad906afca93a557e