### PR TITLE
Implement daily on-time target calculations

### DIFF
--- a/StudyGroupApp/LifeScoreboardView.swift
+++ b/StudyGroupApp/LifeScoreboardView.swift
@@ -111,7 +111,8 @@ struct LifeScoreboardView: View {
                 }
                 .padding(.bottom, 4)
                 
-                OnTimeCard(onTime: viewModel.onTime, travel: viewModel.travel)
+                OnTimeCard(onTime: viewModel.onTimeHonorTarget,
+                           travel: viewModel.onTimeTravelTarget)
 
                 // Team Members section
                 TeamMembersCard(
@@ -211,8 +212,8 @@ private struct ScoreTile<Content: View>: View {
 }
 
 private struct OnTimeCard: View {
-    let onTime: Double
-    let travel: Double
+    let onTime: Int
+    let travel: Int
 
     var body: some View {
         ScoreTile {
@@ -220,7 +221,7 @@ private struct OnTimeCard: View {
                 VStack(spacing: 2) {
                     Text("Honor")
                         .font(.system(size: 20, weight: .bold))
-                    ScoreBadge(text: String(format: "%.1f", onTime), color: .yellow)
+                    ScoreBadge(text: String(onTime), color: .yellow)
                 }
 
                 Spacer()
@@ -233,7 +234,7 @@ private struct OnTimeCard: View {
                 VStack(spacing: 2) {
                     Text("Travel")
                         .font(.system(size: 20, weight: .bold))
-                    ScoreBadge(text: String(format: "%.1f", travel), color: .green)
+                    ScoreBadge(text: String(travel), color: .green)
                 }
             }
             .frame(maxWidth: .infinity)

--- a/StudyGroupApp/LifeScoreboardViewModel.swift
+++ b/StudyGroupApp/LifeScoreboardViewModel.swift
@@ -110,3 +110,35 @@ class LifeScoreboardViewModel: ObservableObject {
         }
     }
 }
+
+// MARK: - On Time Goals
+
+extension LifeScoreboardViewModel {
+
+    /// Yearly policy goals
+    var travelGoal: Int { 70 }
+    var honorGoal: Int { 40 }
+
+    /// The number of days in this year (accounts for leap years)
+    private var daysInYear: Int {
+        let year = Calendar.current.component(.year, from: Date())
+        let components = DateComponents(calendar: .current, year: year)
+        return Calendar.current.range(of: .day, in: .year, for: components.date!)?.count ?? 365
+    }
+
+    /// The current day of the year (1–365/366)
+    private var currentDayOfYear: Int {
+        Calendar.current.ordinality(of: .day, in: .year, for: Date()) ?? 1
+    }
+
+    /// 🎯 Daily-updating On Time Count for Travel
+    var onTimeTravelTarget: Int {
+        Int(round((Double(travelGoal) / Double(daysInYear)) * Double(currentDayOfYear)))
+    }
+
+    /// 🎯 Daily-updating On Time Count for Honor
+    var onTimeHonorTarget: Int {
+        Int(round((Double(honorGoal) / Double(daysInYear)) * Double(currentDayOfYear)))
+    }
+}
+

--- a/StudyGroupApp/TempScoreRowShowcase.swift
+++ b/StudyGroupApp/TempScoreRowShowcase.swift
@@ -209,8 +209,8 @@ private struct ScoreTile<Content: View>: View {
 }
 
 private struct OnTimeCard: View {
-    let onTime: Double
-    let travel: Double
+    let onTime: Int
+    let travel: Int
 
     var body: some View {
         ScoreTile {
@@ -218,7 +218,7 @@ private struct OnTimeCard: View {
                 VStack(spacing: 2) {
                     Text("Honor")
                         .font(.system(size: 17, weight: .semibold))
-                    ScoreBadge(text: String(format: "%.1f", onTime), color: .yellow)
+                    ScoreBadge(text: String(onTime), color: .yellow)
                 }
 
                 Spacer()
@@ -231,7 +231,7 @@ private struct OnTimeCard: View {
                 VStack(spacing: 2) {
                     Text("Travel")
                         .font(.system(size: 17, weight: .semibold))
-                    ScoreBadge(text: String(format: "%.1f", travel), color: .green)
+                    ScoreBadge(text: String(travel), color: .green)
                 }
             }
             .frame(maxWidth: .infinity)
@@ -266,7 +266,7 @@ private struct ScoreboardPage<RowContent: View>: View {
                         .font(.system(size: 15, weight: .regular))
                 }
 
-                OnTimeCard(onTime: 17.7, travel: 31.0)
+                OnTimeCard(onTime: 18, travel: 31)
 
                 Group {
                     VStack(alignment: .leading, spacing: 8) {


### PR DESCRIPTION
## Summary
- compute daily on-time policy counts in `LifeScoreboardViewModel`
- show calculated honor and travel numbers in the scoreboard
- adjust OnTimeCard components to display integer values

## Testing
- `swift --version`
- `swiftc StudyGroupApp/LifeScoreboardViewModel.swift -o /tmp/test.o` *(fails: no such module 'CloudKit')*

------
https://chatgpt.com/codex/tasks/task_e_6845faef4a248322b45feaffd68bd248