### PR TITLE
Remove withTransaction usage

### DIFF
--- a/StudyGroupApp/WinTheDayView.swift
+++ b/StudyGroupApp/WinTheDayView.swift
@@ -242,10 +242,8 @@ private func handleOnAppear() {
     print("🧮 Team Data Count After Load: \(viewModel.teamMembers.count)")
 
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-        withTransaction(Transaction(animation: nil)) {
-            viewModel.reorderCards()
-            viewModel.teamMembers = viewModel.teamMembers.map { $0 }
-        }
+        viewModel.reorderCards()
+        viewModel.teamMembers = viewModel.teamMembers.map { $0 }
     }
 
     withAnimation(Animation.linear(duration: 8).repeatForever(autoreverses: false)) {

--- a/StudyGroupApp/WinTheDayViewModel.swift
+++ b/StudyGroupApp/WinTheDayViewModel.swift
@@ -108,17 +108,13 @@ class WinTheDayViewModel: ObservableObject {
                 let ordered = savedOrder.compactMap { idString in
                     self.teamMembers.first { $0.id.uuidString == idString }
                 }
-                withTransaction(Transaction(animation: nil)) {
-                    self.displayedCards = ordered
-                }
+                self.displayedCards = ordered
             } else {
                 let sorted = self.teamMembers.sorted {
                     ($0.quotesToday + $0.salesWTD + $0.salesMTD) >
                     ($1.quotesToday + $1.salesWTD + $1.salesMTD)
                 }
-                withTransaction(Transaction(animation: nil)) {
-                    self.displayedCards = sorted
-                }
+                self.displayedCards = sorted
             }
         }
     }


### PR DESCRIPTION
## Summary
- drop uses of `withTransaction` when reordering cards
- update `loadCardOrderFromCloud` to assign data directly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684615ab597483229426e7aeefe3c566