### PR TITLE
Remove CloudKit card order sync

### DIFF
--- a/CloudKitManager.swift
+++ b/CloudKitManager.swift
@@ -6,7 +6,6 @@ class CloudKitManager: ObservableObject {
     private let database = CKContainer(identifier: "iCloud.com.dj.Outcast").publicCloudDatabase
     private let recordType = "TeamMember"
     private let scoreRecordType = "ScoreRecord"
-    private let cardOrderRecordType = "CardOrder"
 
     @Published var team: [TeamMember] = []
 
@@ -340,52 +339,4 @@ class CloudKitManager: ObservableObject {
         database.add(operation)
     }
 
-    // MARK: - Card Order
-    func fetchCardOrder(for user: String, completion: @escaping ([String]?) -> Void) {
-        let predicate = NSPredicate(format: "userName == %@", user)
-        let query = CKQuery(recordType: cardOrderRecordType, predicate: predicate)
-        let operation = CKQueryOperation(query: query)
-        operation.resultsLimit = 1
-
-        var savedOrder: [String]?
-        operation.recordMatchedBlock = { _, result in
-            if case .success(let record) = result {
-                savedOrder = record["cardOrder"] as? [String]
-            }
-        }
-
-        operation.queryResultBlock = { _ in
-            DispatchQueue.main.async {
-                completion(savedOrder)
-            }
-        }
-
-        database.add(operation)
-    }
-
-    func saveCardOrder(for user: String, order: [String]) {
-        let predicate = NSPredicate(format: "userName == %@", user)
-        let query = CKQuery(recordType: cardOrderRecordType, predicate: predicate)
-        let operation = CKQueryOperation(query: query)
-        operation.resultsLimit = 1
-
-        var matchedRecord: CKRecord?
-        operation.recordMatchedBlock = { _, result in
-            if case .success(let record) = result {
-                matchedRecord = record
-            }
-        }
-
-        operation.queryResultBlock = { _ in
-            let record = matchedRecord ?? CKRecord(recordType: self.cardOrderRecordType)
-            record["userName"] = user as CKRecordValue
-            record["cardOrder"] = order as CKRecordValue
-
-            let modify = CKModifyRecordsOperation(recordsToSave: [record], recordIDsToDelete: nil)
-            modify.modifyRecordsResultBlock = { _ in }
-            self.database.add(modify)
-        }
-
-        database.add(operation)
-    }
 }


### PR DESCRIPTION
## Summary
- remove card-order APIs from `CloudKitManager`
- update `WinTheDayViewModel` to manage local card order
- sort cards locally on first load and after saves
- update `WinTheDayView` to use new ordering logic and drop CloudKit order calls

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68461ce72c448322bb471b56d4014218