### PR TITLE
Restore card sync, remove order persistence

### DIFF
--- a/Outcast/TeamMember.swift
+++ b/Outcast/TeamMember.swift
@@ -81,8 +81,7 @@ extension TeamMember {
             let quotesGoal = record["quotesGoal"] as? Int,
             let salesWTDGoal = record["salesWTDGoal"] as? Int,
             let salesMTDGoal = record["salesMTDGoal"] as? Int,
-            let emoji = record["emoji"] as? String,
-            let sortIndex = record["sortIndex"] as? Int
+            let emoji = record["emoji"] as? String
         else {
             return nil
         }
@@ -97,7 +96,7 @@ extension TeamMember {
             salesWTDGoal: salesWTDGoal,
             salesMTDGoal: salesMTDGoal,
             emoji: emoji,
-            sortIndex: sortIndex
+            sortIndex: 0
         )
     }
 
@@ -112,7 +111,6 @@ extension TeamMember {
         record["salesWTDGoal"] = salesWTDGoal as CKRecordValue
         record["salesMTDGoal"] = salesMTDGoal as CKRecordValue
         record["emoji"] = emoji as CKRecordValue
-        record["sortIndex"] = sortIndex as CKRecordValue
         return record
     }
 

--- a/StudyGroupApp/TeamMember.swift
+++ b/StudyGroupApp/TeamMember.swift
@@ -140,8 +140,7 @@ extension TeamMember {
             let quotesGoal = record["quotesGoal"] as? Int,
             let salesWTDGoal = record["salesWTDGoal"] as? Int,
             let salesMTDGoal = record["salesMTDGoal"] as? Int,
-            let emoji = record["emoji"] as? String,
-            let sortIndex = record["sortIndex"] as? Int
+            let emoji = record["emoji"] as? String
         else {
             return nil
         }
@@ -156,7 +155,7 @@ extension TeamMember {
             salesWTDGoal: salesWTDGoal,
             salesMTDGoal: salesMTDGoal,
             emoji: emoji,
-            sortIndex: sortIndex
+            sortIndex: 0
         )
     }
 
@@ -170,7 +169,6 @@ extension TeamMember {
         record["salesWTDGoal"] = salesWTDGoal as CKRecordValue
         record["salesMTDGoal"] = salesMTDGoal as CKRecordValue
         record["emoji"] = emoji as CKRecordValue
-        record["sortIndex"] = sortIndex as CKRecordValue
         return record
     }
 }


### PR DESCRIPTION
## Summary
- restore Win the Day CloudKit syncing implementation
- stop persisting `sortIndex` to CloudKit

## Testing
- `xcodebuild -list -project StudyGroupApp/StudyGroupApp.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684625b2132083228a0951d62367345c