### PR TITLE
Restore CloudKit syncing for splash and WTD

### DIFF
--- a/StudyGroupApp/SplashViewModel.swift
+++ b/StudyGroupApp/SplashViewModel.swift
@@ -1,0 +1,27 @@
+import Foundation
+import CloudKit
+
+class SplashViewModel: ObservableObject {
+    @Published var users: [String] = []
+
+    /// Fetch the user list from CloudKit and update ``users``.
+    func fetchUsersFromCloud() {
+        CloudKitManager.fetchUsers { fetched in
+            DispatchQueue.main.async {
+                self.users = fetched
+            }
+        }
+    }
+
+    /// Add a new user both locally and in CloudKit.
+    func addUser(_ name: String) {
+        CloudKitManager.saveUser(name)
+        fetchUsersFromCloud()
+    }
+
+    /// Delete a user from CloudKit and refresh the list.
+    func deleteUser(_ name: String) {
+        CloudKitManager.deleteUser(name)
+        fetchUsersFromCloud()
+    }
+}

--- a/StudyGroupApp/UserSelectorView.swift
+++ b/StudyGroupApp/UserSelectorView.swift
@@ -87,7 +87,7 @@ struct UserSelectorView: View {
                 }
             }
             .onAppear {
-                userManager.refresh()
+                userManager.fetchUsersFromCloud()
             }
         }
     }

--- a/StudyGroupApp/WinTheDayView.swift
+++ b/StudyGroupApp/WinTheDayView.swift
@@ -255,7 +255,7 @@ private var teamCardsList: some View {
         ScrollView {
             VStack(spacing: 10) {
 
-                ForEach(viewModel.displayedCards, id: \.id) { card in
+                ForEach(viewModel.displayedMembers, id: \.id) { card in
                     if let idx = viewModel.teamMembers.firstIndex(where: { $0.id == card.id }) {
                         let name = viewModel.teamMembers[idx].name
                         let isEditable = name == userManager.currentUser

--- a/StudyGroupApp/WinTheDayViewModel.swift
+++ b/StudyGroupApp/WinTheDayViewModel.swift
@@ -9,9 +9,9 @@ class WinTheDayViewModel: ObservableObject {
         self.teamMembers = []
     }
     @Published var teamMembers: [TeamMember] = []
-    @Published var displayedCards: [TeamMember] = []
+    @Published var displayedMembers: [TeamMember] = []
     @Published var cards: [Card] = []
-    @Published var displayedCardModels: [Card] = []
+    @Published var displayedCards: [Card] = []
     @Published var selectedUserName: String = ""
     private let storageKey = "WTDMemberStorage"
     private var hasLoadedDisplayOrder = false
@@ -20,7 +20,7 @@ class WinTheDayViewModel: ObservableObject {
     /// This mirrors the stable ordering used by Life Scoreboard.
     func loadInitialDisplayOrder() {
         guard !hasLoadedDisplayOrder else { return }
-        displayedCards = teamMembers.sorted {
+        displayedMembers = teamMembers.sorted {
             ($0.quotesToday + $0.salesWTD + $0.salesMTD) >
             ($1.quotesToday + $1.salesWTD + $1.salesMTD)
         }
@@ -29,7 +29,7 @@ class WinTheDayViewModel: ObservableObject {
 
     /// Reorders ``displayedCards`` after the user saves edits.
     func reorderAfterSave() {
-        displayedCards = teamMembers.sorted {
+        displayedMembers = teamMembers.sorted {
             ($0.quotesToday + $0.salesWTD + $0.salesMTD) >
             ($1.quotesToday + $1.salesWTD + $1.salesMTD)
         }
@@ -41,15 +41,15 @@ class WinTheDayViewModel: ObservableObject {
         CloudKitManager.fetchCards { fetched in
             DispatchQueue.main.async {
                 self.cards = fetched
-                self.displayedCardModels = fetched.sorted { $0.production > $1.production }
+                self.displayedCards = fetched.sorted { $0.production > $1.production }
             }
         }
     }
 
-    func saveCardEdits(for card: Card) {
+    func saveEdits(for card: Card) {
         CloudKitManager.saveCard(card)
         withAnimation {
-            displayedCardModels = cards.sorted { $0.production > $1.production }
+            displayedCards = cards.sorted { $0.production > $1.production }
         }
     }
 


### PR DESCRIPTION
## Summary
- fetch/save/delete users via CloudKit
- provide CloudKit helpers for cards with simplified logic
- add SplashViewModel for splash screen syncing
- update UserManager to use CloudKit and refresh on appear
- keep card order local-only in WinTheDayViewModel

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6846289a01d883229f784f2f50603a11