### PR TITLE
Fix unterminated string literal in CloudKitManager

### DIFF
--- a/CloudKitManager.swift
+++ b/CloudKitManager.swift
@@ -349,7 +349,8 @@ class CloudKitManager: ObservableObject {
         let query = CKQuery(recordType: userRecordType, predicate: predicate)
         CKContainer.default().publicCloudDatabase.perform(query, inZoneWith: nil) { records, error in
             guard let records = records, error == nil else {
-                print("❌ Failed to fetch users: \(error?.localizedDescription ?? \"Unknown error\")")
+                let message = error?.localizedDescription ?? "Unknown error"
+                print("❌ Failed to fetch users: \(message)")
                 completion([])
                 return
             }


### PR DESCRIPTION
## Summary
- fix error message construction when fetching users from CloudKit

## Testing
- `swiftc -parse CloudKitManager.swift`


------
https://chatgpt.com/codex/tasks/task_e_68462b80d6b083229eadddd3e0669728