### PR TITLE
Fix CloudKit container usage

### DIFF
--- a/CloudKitManager.swift
+++ b/CloudKitManager.swift
@@ -3,7 +3,9 @@ import Foundation
 
 class CloudKitManager: ObservableObject {
     static let shared = CloudKitManager()
-    private let database = CKContainer(identifier: "iCloud.com.dj.Outcast").publicCloudDatabase
+    /// The primary iCloud container for all app data.
+    static let container = CKContainer(identifier: "iCloud.com.dj.Outcast")
+    private let database = CloudKitManager.container.publicCloudDatabase
     private let recordType = "TeamMember"
     private let scoreRecordType = "ScoreRecord"
     private let cardRecordType = "Card"
@@ -347,7 +349,7 @@ class CloudKitManager: ObservableObject {
     static func fetchUsers(completion: @escaping ([String]) -> Void) {
         let predicate = NSPredicate(value: true)
         let query = CKQuery(recordType: userRecordType, predicate: predicate)
-        CKContainer.default().publicCloudDatabase.perform(query, inZoneWith: nil) { records, error in
+        CloudKitManager.container.publicCloudDatabase.perform(query, inZoneWith: nil) { records, error in
             guard let records = records, error == nil else {
                 let message = error?.localizedDescription ?? "Unknown error"
                 print("❌ Failed to fetch users: \(message)")
@@ -364,7 +366,7 @@ class CloudKitManager: ObservableObject {
     static func saveUser(_ name: String, completion: @escaping () -> Void) {
         let record = CKRecord(recordType: userRecordType, recordID: CKRecord.ID(recordName: name))
         record["name"] = name as CKRecordValue
-        CKContainer.default().publicCloudDatabase.save(record) { _, error in
+        CloudKitManager.container.publicCloudDatabase.save(record) { _, error in
             if let error = error {
                 print("❌ Error saving user: \(error)")
             } else {
@@ -377,7 +379,7 @@ class CloudKitManager: ObservableObject {
     /// Deletes the user with the given name from CloudKit.
     static func deleteUser(_ name: String) {
         let id = CKRecord.ID(recordName: name)
-        CKContainer.default().publicCloudDatabase.delete(withRecordID: id) { _, _ in }
+        CloudKitManager.container.publicCloudDatabase.delete(withRecordID: id) { _, _ in }
     }
 
     // MARK: - Card Sync
@@ -385,7 +387,7 @@ class CloudKitManager: ObservableObject {
     /// Fetches all Win the Day cards from CloudKit.
     static func fetchCards(completion: @escaping ([Card]) -> Void) {
         let query = CKQuery(recordType: shared.cardRecordType, predicate: NSPredicate(value: true))
-        CKContainer.default().publicCloudDatabase.perform(query, inZoneWith: nil) { records, error in
+        CloudKitManager.container.publicCloudDatabase.perform(query, inZoneWith: nil) { records, error in
             guard let records = records, error == nil else {
                 completion([])
                 return
@@ -398,7 +400,7 @@ class CloudKitManager: ObservableObject {
     /// Saves a Win the Day card to CloudKit.
     static func saveCard(_ card: Card) {
         let record = card.toCKRecord()
-        CKContainer.default().publicCloudDatabase.save(record) { _, _ in }
+        CloudKitManager.container.publicCloudDatabase.save(record) { _, _ in }
     }
 
 }

--- a/CloudKitProbeView.swift
+++ b/CloudKitProbeView.swift
@@ -22,7 +22,7 @@ struct CloudKitProbeView: View {
     }
 
     func checkCloudKit() {
-        CKContainer.default().accountStatus { status, error in
+        CKContainer(identifier: "iCloud.com.dj.Outcast").accountStatus { status, error in
             DispatchQueue.main.async {
                 switch status {
                 case .available:

--- a/CloudKitTestPusher.swift
+++ b/CloudKitTestPusher.swift
@@ -32,7 +32,7 @@ struct CloudKitTestPusher: View {
         let record = CKRecord(recordType: "TestRecord")
         record["note"] = "This is a test from D.J." as CKRecordValue
 
-        CKContainer.default().privateCloudDatabase.save(record) { savedRecord, error in
+        CKContainer(identifier: "iCloud.com.dj.Outcast").privateCloudDatabase.save(record) { savedRecord, error in
             DispatchQueue.main.async {
                 if let error = error {
                     resultMessage = "❌ Failed to save: \(error.localizedDescription)"

--- a/Outcast/StudyGroupApp.swift
+++ b/Outcast/StudyGroupApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 @main
 struct StudyGroupApp: App {
     init() {
-        CKContainer.default().accountStatus { status, error in
+        CKContainer(identifier: "iCloud.com.dj.Outcast").accountStatus { status, error in
             DispatchQueue.main.async {
                 switch status {
                 case .available:

--- a/Outcast/WinTheDayViewModel.swift
+++ b/Outcast/WinTheDayViewModel.swift
@@ -3,7 +3,8 @@ import CloudKit
 
 class WinTheDayViewModel: ObservableObject {
     @Published var teamData: [TeamMember] = []
-    private var database = CKContainer.default().publicCloudDatabase
+    /// Use the Outcast container explicitly for all sync operations.
+    private let database = CKContainer(identifier: "iCloud.com.dj.Outcast").publicCloudDatabase
 
     init() {
         fetchTeamMembers()
@@ -36,7 +37,7 @@ class WinTheDayViewModel: ObservableObject {
             }
         }
 
-        CKContainer.default().publicCloudDatabase.add(operation)
+        database.add(operation)
     }
 
     func fetchTeamMembers() {
@@ -93,7 +94,7 @@ class WinTheDayViewModel: ObservableObject {
             }
         }
 
-        CKContainer.default().publicCloudDatabase.add(operation)
+        database.add(operation)
     }
 } // End of class WinTheDayViewModel
 

--- a/StudyGroupApp/LifeScoreboardViewModel.swift
+++ b/StudyGroupApp/LifeScoreboardViewModel.swift
@@ -2,7 +2,8 @@ import CloudKit
 import Foundation
 
 class LifeScoreboardViewModel: ObservableObject {
-    private let container = CKContainer.default()
+    /// Use the shared Outcast container for scoreboard records.
+    private let container = CKContainer(identifier: "iCloud.com.dj.Outcast")
     private let recordType = "ScoreRecord"
 
     @Published var scores: [ScoreEntry] = []


### PR DESCRIPTION
## Summary
- define a shared `CKContainer` pointing to `iCloud.com.dj.Outcast`
- update all sync code to use the Outcast container explicitly

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68462e4c5cfc832280b9336a2d68f2cc