### PR TITLE
Add CloudKit team member support

### DIFF
--- a/StudyGroupApp/SplashViewModel.swift
+++ b/StudyGroupApp/SplashViewModel.swift
@@ -2,28 +2,29 @@ import Foundation
 import CloudKit
 
 class SplashViewModel: ObservableObject {
-    @Published var users: [String] = []
+    /// Team members available for selection on the splash screen.
+    @Published var teamMembers: [TeamMember] = []
 
-    /// Fetch the user list from CloudKit and update ``users``.
-    func fetchUsersFromCloud() {
-        CloudKitManager.fetchUsers { fetched in
+    /// Fetches all members from CloudKit and updates ``teamMembers``.
+    func fetchMembersFromCloud() {
+        CloudKitManager.shared.fetchAllTeamMembers { fetched in
             DispatchQueue.main.async {
-                print("✅ Cloud returned users: \(fetched)")
-                self.users = fetched
+                self.teamMembers = fetched
             }
         }
     }
 
-    /// Add a new user both locally and in CloudKit.
-    func addUser(_ name: String) {
-        CloudKitManager.saveUser(name) { [weak self] in
-            self?.fetchUsersFromCloud()
+    /// Adds a new member record and refreshes ``teamMembers``.
+    func addMember(name: String, emoji: String = "🙂") {
+        CloudKitManager.shared.addTeamMember(name: name, emoji: emoji) { [weak self] _ in
+            self?.fetchMembersFromCloud()
         }
     }
 
-    /// Delete a user from CloudKit and refresh the list.
-    func deleteUser(_ name: String) {
-        CloudKitManager.deleteUser(name)
-        fetchUsersFromCloud()
+    /// Deletes the provided member record and refreshes the list.
+    func deleteMember(_ member: TeamMember) {
+        CloudKitManager.shared.deleteTeamMember(member) { [weak self] _ in
+            self?.fetchMembersFromCloud()
+        }
     }
 }

--- a/StudyGroupApp/StudyGroupApp.xcodeproj/project.pbxproj
+++ b/StudyGroupApp/StudyGroupApp.xcodeproj/project.pbxproj
@@ -17,8 +17,9 @@
                 B653C53F2DE2407A001B905F /* TeamMember.swift in Sources */ = {isa = PBXBuildFile; fileRef = B653C53E2DE2407A001B905F /* TeamMember.swift */; };
                 A1B2C3D42DEFCAFE00000001 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D32DEFCAFE00000001 /* Card.swift */; };
                 B653C5412DE2409D001B905F /* StudyGroupApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B653C5402DE2409D001B905F /* StudyGroupApp.swift */; };
-		B653C54B2DE26ED8001B905F /* CloudKitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B653C54A2DE26ED8001B905F /* CloudKitManager.swift */; };
-		B653C54D2DE270A5001B905F /* UserSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B653C54C2DE270A5001B905F /* UserSelectorView.swift */; };
+                B653C54B2DE26ED8001B905F /* CloudKitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B653C54A2DE26ED8001B905F /* CloudKitManager.swift */; };
+                FEED00012DEFCAFE00000002 /* SplashViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED00002DEFCAFE00000002 /* SplashViewModel.swift */; };
+                B653C54D2DE270A5001B905F /* UserSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B653C54C2DE270A5001B905F /* UserSelectorView.swift */; };
 		B6C560BE2DEFC65500F64256 /* LifeScoreboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C560BD2DEFC65500F64256 /* LifeScoreboardView.swift */; };
 		B6C560C02DEFC75800F64256 /* LifeScoreboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C560BF2DEFC75800F64256 /* LifeScoreboardViewModel.swift */; };
 		B6C560C62DEFCC0E00F64256 /* ActivityEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C560C52DEFCC0E00F64256 /* ActivityEditorView.swift */; };
@@ -42,8 +43,9 @@
                 B653C53E2DE2407A001B905F /* TeamMember.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamMember.swift; sourceTree = "<group>"; };
                 A1B2C3D32DEFCAFE00000001 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
                 B653C5402DE2409D001B905F /* StudyGroupApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyGroupApp.swift; sourceTree = "<group>"; };
-		B653C54A2DE26ED8001B905F /* CloudKitManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CloudKitManager.swift; path = ../CloudKitManager.swift; sourceTree = "<group>"; };
-		B653C54C2DE270A5001B905F /* UserSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSelectorView.swift; sourceTree = "<group>"; };
+                B653C54A2DE26ED8001B905F /* CloudKitManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CloudKitManager.swift; path = ../CloudKitManager.swift; sourceTree = "<group>"; };
+                FEED00002DEFCAFE00000002 /* SplashViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewModel.swift; sourceTree = "<group>"; };
+                B653C54C2DE270A5001B905F /* UserSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSelectorView.swift; sourceTree = "<group>"; };
 		B6C560BD2DEFC65500F64256 /* LifeScoreboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeScoreboardView.swift; sourceTree = "<group>"; };
 		B6C560BF2DEFC75800F64256 /* LifeScoreboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifeScoreboardViewModel.swift; sourceTree = "<group>"; };
 		B6C560C52DEFCC0E00F64256 /* ActivityEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityEditorView.swift; sourceTree = "<group>"; };
@@ -72,8 +74,9 @@
 				B6CB20692DE3D90A00CE7A18 /* LaunchScreenView.swift */,
 				B6CB20682DE3B35B00CE7A18 /* StudyGroupApp.entitlements */,
 				B653C54C2DE270A5001B905F /* UserSelectorView.swift */,
-				B653C54A2DE26ED8001B905F /* CloudKitManager.swift */,
-				331336D4828944B798561421 /* UserManager.swift */,
+                                B653C54A2DE26ED8001B905F /* CloudKitManager.swift */,
+                                FEED00002DEFCAFE00000002 /* SplashViewModel.swift */,
+                                331336D4828944B798561421 /* UserManager.swift */,
 				B653C5282DE23D36001B905F /* MainTabView.swift */,
                                B653C53E2DE2407A001B905F /* TeamMember.swift */,
                                 A1B2C3D32DEFCAFE00000001 /* Card.swift */,
@@ -180,8 +183,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				B6C560C02DEFC75800F64256 /* LifeScoreboardViewModel.swift in Sources */,
-				B653C54B2DE26ED8001B905F /* CloudKitManager.swift in Sources */,
-				64C6F0F5FC38411D819C0BE3 /* UserManager.swift in Sources */,
+                                B653C54B2DE26ED8001B905F /* CloudKitManager.swift in Sources */,
+                                FEED00012DEFCAFE00000002 /* SplashViewModel.swift in Sources */,
+                                64C6F0F5FC38411D819C0BE3 /* UserManager.swift in Sources */,
 				B653C5412DE2409D001B905F /* StudyGroupApp.swift in Sources */,
 				B653C53D2DE2403E001B905F /* WinTheDayView.swift in Sources */,
                                B653C53F2DE2407A001B905F /* TeamMember.swift in Sources */,


### PR DESCRIPTION
## Summary
- rename `team` to `teamMembers` in `CloudKitManager`
- add helpers for fetching, adding and deleting members
- track members in `SplashViewModel` and `UserSelectorView`
- show emoji and name when selecting a user
- include `SplashViewModel.swift` in the project

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684630a9b434832290492d60b4bc3811