### PR TITLE
Set currentUser before user fetch

### DIFF
--- a/StudyGroupApp/UserSelectorView.swift
+++ b/StudyGroupApp/UserSelectorView.swift
@@ -32,7 +32,8 @@ struct UserSelectorView: View {
                             List {
                                 ForEach(cloud.teamMembers, id: \.id) { member in
                                     Button(action: {
-                                        userManager.selectUser(member.name)
+                                        userManager.currentUser = member.name
+                                        userManager.fetchUsersFromCloud()
                                         print("👤 Selected: \(member.name)")
                                         navigate = true
                                     }) {


### PR DESCRIPTION
## Summary
- update user selection tap action to set `currentUser`
- trigger CloudKit user fetch after setting the user

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848ec377dc48322b92bcc8d625f8f3b