### PR TITLE
Fix user fetch on name selection

### DIFF
--- a/CloudKitManager.swift
+++ b/CloudKitManager.swift
@@ -490,6 +490,17 @@ class CloudKitManager: ObservableObject {
         }
     }
 
+    /// Convenience wrapper that uses ``UserManager``'s current user.
+    /// Calls ``fetchUsers(for:completion:)`` and simply prints the results.
+    func fetchUsers() {
+        let current = UserManager.shared.currentUser
+        CloudKitManager.fetchUsers(for: current) { names in
+            DispatchQueue.main.async {
+                print("📥 Received users from CloudKit: \(names)")
+            }
+        }
+    }
+
     /// Saves the provided user name to CloudKit.
     static func saveUser(_ name: String, completion: @escaping () -> Void) {
         let record = CKRecord(recordType: userRecordType, recordID: CKRecord.ID(recordName: name))

--- a/StudyGroupApp/UserSelectorView.swift
+++ b/StudyGroupApp/UserSelectorView.swift
@@ -33,7 +33,7 @@ struct UserSelectorView: View {
                                 ForEach(cloud.teamMembers, id: \.id) { member in
                                     Button(action: {
                                         userManager.currentUser = member.name
-                                        userManager.fetchUsersFromCloud()
+                                        cloud.fetchUsers()
                                         print("👤 Selected: \(member.name)")
                                         navigate = true
                                     }) {


### PR DESCRIPTION
## Summary
- add convenience `fetchUsers()` wrapper to `CloudKitManager`
- update user card action to set the current user then fetch users

## Testing
- `git diff --cached --stat`

------
https://chatgpt.com/codex/tasks/task_e_6848ee10eeb483229fdc13bb94009d7d