### PR TITLE
Remove emoji from splash screen

### DIFF
--- a/StudyGroupApp/UserSelectorView.swift
+++ b/StudyGroupApp/UserSelectorView.swift
@@ -38,13 +38,10 @@ struct UserSelectorView: View {
                                         print("👤 Selected: \(member.name)")
                                         navigate = true
                                     }) {
-                                        HStack {
-                                            Text(member.emoji)
-                                            Text(member.name)
-                                        }
-                                        .font(.system(size: 26, weight: .bold))
-                                        .foregroundColor(.white)
-                                        .frame(maxWidth: .infinity)
+                                        Text(member.name)
+                                            .font(.system(size: 26, weight: .bold))
+                                            .foregroundColor(.white)
+                                            .frame(maxWidth: .infinity)
                                             .padding()
                                             .padding(.vertical, 6)
                                             .background(Color.red)


### PR DESCRIPTION
## Summary
- fix user list to show only the user's name

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684a18ec1ae48322a8d30ab00d7f6ffb