### PR TITLE
Fix Win the Day team loading

### DIFF
--- a/StudyGroupApp/WinTheDayView.swift
+++ b/StudyGroupApp/WinTheDayView.swift
@@ -80,30 +80,22 @@ struct WinTheDayView: View {
             }
         }
         .onAppear {
-            cloud.fetchTeam { _ in }
-            if !userManager.userList.isEmpty {
-                viewModel.load(names: userManager.userList) {
-                    viewModel.loadCardOrderFromCloud(for: userManager.currentUser)
-                }
-                viewModel.loadInitialDisplayOrder()
-                viewModel.fetchCardsFromCloud()
-                hasLoaded = true
-                shimmerPosition = -1.0
-                viewModel.initializeDisplayedCardsIfNeeded()
-                withAnimation(Animation.linear(duration: 12).repeatForever(autoreverses: false)) {
-                    shimmerPosition = 1.5
-                }
-            } else {
-                print("⚠️ Skipped loadData in onAppear: currentUser is empty")
+            viewModel.fetchMembersFromCloud {
+                viewModel.loadCardOrderFromCloud(for: userManager.currentUser)
+            }
+            viewModel.fetchCardsFromCloud()
+            hasLoaded = true
+            shimmerPosition = -1.0
+            withAnimation(Animation.linear(duration: 12).repeatForever(autoreverses: false)) {
+                shimmerPosition = 1.5
             }
         }
     .onChange(of: userManager.currentUser) { _ in }
-    .onChange(of: userManager.userList) { newList in
+    .onChange(of: userManager.userList) { _ in
         if hasLoaded {
-            viewModel.load(names: newList) {
+            viewModel.fetchMembersFromCloud {
                 viewModel.loadCardOrderFromCloud(for: userManager.currentUser)
             }
-            viewModel.initializeDisplayedCardsIfNeeded()
         }
     }
     .sheet(isPresented: $emojiPickerVisible) {
@@ -300,7 +292,7 @@ private var teamCardsList: some View {
             .padding(.horizontal, 20)
         }
         .refreshable {
-            viewModel.load(names: userManager.userList) {
+            viewModel.fetchMembersFromCloud {
                 viewModel.loadCardOrderFromCloud(for: userManager.currentUser)
             }
         }

--- a/StudyGroupApp/WinTheDayViewModel.swift
+++ b/StudyGroupApp/WinTheDayViewModel.swift
@@ -52,6 +52,18 @@ class WinTheDayViewModel: ObservableObject {
         }
     }
 
+    /// Fetches all ``TeamMember`` records from CloudKit and updates ``teamMembers``.
+    /// This mirrors the behavior used on the splash screen so both views stay in sync.
+    func fetchMembersFromCloud(completion: (() -> Void)? = nil) {
+        CloudKitManager.shared.fetchAllTeamMembers { [weak self] fetched in
+            DispatchQueue.main.async {
+                self?.teamMembers = fetched
+                self?.displayedMembers = fetched.sorted { $0.sortIndex < $1.sortIndex }
+                completion?()
+            }
+        }
+    }
+
     func saveEdits(for card: Card) {
         CloudKitManager.saveCard(card)
         withAnimation {


### PR DESCRIPTION
## Summary
- load team members from CloudKit in WinTheDayViewModel
- refresh team cards in WinTheDayView using new fetch method

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684a1a5edd6c832293b030dbfeb581b3