### PR TITLE
Fix persistent CloudKit loading for Life Scoreboard

### DIFF
--- a/StudyGroupApp/LifeScoreboardView.swift
+++ b/StudyGroupApp/LifeScoreboardView.swift
@@ -136,14 +136,10 @@ struct LifeScoreboardView: View {
             .padding()
         }
         .onAppear {
-            viewModel.fetchTeamMembersFromCloud()
-        }
-        .onReceive(viewModel.$teamMembers) { members in
-            let names = members.map { $0.name }
-            viewModel.load(for: names)
+            viewModel.loadFromCloud()
         }
         .refreshable {
-            viewModel.fetchTeamMembersFromCloud()
+            viewModel.loadFromCloud()
         }
         .background(
             LinearGradient(


### PR DESCRIPTION
## Summary
- add a `loadFromCloud` helper in `LifeScoreboardViewModel` to pull user data directly from CloudKit
- update `LifeScoreboardView` to use the new loader on appear and refresh

## Testing
- `swiftc --version`

------
https://chatgpt.com/codex/tasks/task_e_684a260f86148322ab236ebe47bd9730