### PR TITLE
Refine Activity Card headers

### DIFF
--- a/StudyGroupApp/LifeScoreboardView.swift
+++ b/StudyGroupApp/LifeScoreboardView.swift
@@ -347,14 +347,16 @@ private struct ActivityCard: View {
 
         return ScoreTile(verticalPadding: 8) {
             VStack(alignment: .leading, spacing: 6) {
-                Text("Activity")
-                    .font(.system(size: 21, weight: .bold))
-                    .frame(maxWidth: .infinity, alignment: .center)
+                HStack(spacing: 6) {
+                    Spacer()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Text("Activity")
+                        .font(.system(size: 21, weight: .bold))
+                        .frame(minWidth: 190, alignment: .center)
+                }
 
                 HStack(spacing: 6) {
-                    Text("Name")
-                        .font(.system(size: 19, weight: .bold))
-                        .monospacedDigit()
+                    Spacer()
                         .frame(maxWidth: .infinity, alignment: .leading)
 
                     Text("Pending")

--- a/StudyGroupApp/TempScoreRowShowcase.swift
+++ b/StudyGroupApp/TempScoreRowShowcase.swift
@@ -310,13 +310,16 @@ private struct ActivityCard: View {
     var body: some View {
         ScoreTile(verticalPadding: 8) {
             VStack(alignment: .leading, spacing: 6) {
-                Text("Activity")
-                    .font(.system(size: 20, weight: .bold))
-                    .frame(maxWidth: .infinity, alignment: .center)
+                HStack(spacing: 6) {
+                    Spacer()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Text("Activity")
+                        .font(.system(size: 20, weight: .bold))
+                        .frame(minWidth: 180, alignment: .center)
+                }
 
                 HStack(spacing: 6) {
-                    Text("Name")
-                        .font(.system(size: 16, weight: .bold))
+                    Spacer()
                         .frame(maxWidth: .infinity, alignment: .leading)
                     Text("Pending")
                         .font(.system(size: 16, weight: .bold))


### PR DESCRIPTION
## Summary
- tweak headers in LifeScoreboard activity table
- update showcase view for consistency

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684a2732d7588322bde97503e0af22ce