### PR TITLE
Fix scoreboard load behavior

### DIFF
--- a/StudyGroupApp/LifeScoreboardView.swift
+++ b/StudyGroupApp/LifeScoreboardView.swift
@@ -136,10 +136,10 @@ struct LifeScoreboardView: View {
             .padding()
         }
         .onAppear {
-            viewModel.loadFromCloud()
+            viewModel.loadIfNeeded()
         }
         .refreshable {
-            viewModel.loadFromCloud()
+            viewModel.refreshFromCloud()
         }
         .background(
             LinearGradient(


### PR DESCRIPTION
## Summary
- avoid clearing names on each view appearance
- keep in-memory data loaded until CloudKit reports a change
- allow manual refresh to force a reload

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684a3101b9b48322b2ce4b386e2b071c