### PR TITLE
Refactor Life Scoreboard syncing

### DIFF
--- a/StudyGroupApp/LifeScoreboardView.swift
+++ b/StudyGroupApp/LifeScoreboardView.swift
@@ -255,9 +255,7 @@ private struct TeamMembersCard: View {
     }
 
     var body: some View {
-        let sortedNames = userManager.userList.sorted { lhs, rhs in
-            viewModel.score(for: lhs) > viewModel.score(for: rhs)
-        }
+        let sortedNames = viewModel.scores.sorted { $0.sortIndex < $1.sortIndex }.map { $0.name }
 
         return ScoreTile(verticalPadding: 8) {
             VStack(alignment: .leading, spacing: 8) {
@@ -344,9 +342,8 @@ private struct ActivityCard: View {
     var onSelect: (LifeScoreboardViewModel.ScoreEntry, LifeScoreboardViewModel.ActivityRow) -> Void
 
     var body: some View {
-        let sortedRows = userManager.userList
-            .compactMap { viewModel.row(for: $0) }
-            .sorted { $0.projected > $1.projected }
+        let sortedRows = viewModel.scores.sorted { $0.sortIndex < $1.sortIndex }
+            .compactMap { viewModel.row(for: $0.name) }
 
         return ScoreTile(verticalPadding: 8) {
             VStack(alignment: .leading, spacing: 6) {


### PR DESCRIPTION
## Summary
- store scoreboard data locally to avoid constant CloudKit fetches
- compute change hashes and reorder only when CloudKit data differs
- persist `ScoreEntry` order and keep progress bars stable
- sort Team and Activity sections based on local order

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a4e09ccf083229443823d40d5971f