### PR TITLE
Fix Activity card layout

### DIFF
--- a/StudyGroupApp/LifeScoreboardView.swift
+++ b/StudyGroupApp/LifeScoreboardView.swift
@@ -351,6 +351,10 @@ private struct ActivityCard: View {
                     .frame(maxWidth: .infinity, alignment: .center)
 
                 HStack(spacing: 6) {
+                    // Spacer maintains name column width without a heading
+                    Color.clear
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
                     Text("Pending")
                         .font(.system(size: 19, weight: .bold))
                         .monospacedDigit()
@@ -362,7 +366,6 @@ private struct ActivityCard: View {
                         .monospacedDigit()
                         .frame(minWidth: 110, alignment: .trailing)
                 }
-                .frame(maxWidth: .infinity, alignment: .center)
 
                 ForEach(sortedRows, id: \.id) { row in
                     if let entry = viewModel.entry(for: row.name) {
@@ -387,6 +390,16 @@ private struct ActivityRowView: View {
 
     var body: some View {
         HStack(spacing: 6) {
+            Text(row.name)
+                .font(
+                    .system(
+                        size: 19,
+                        weight: .regular,
+                        design: .rounded
+                    )
+                )
+                .monospacedDigit()
+                .frame(maxWidth: .infinity, alignment: .leading)
             Text("\(row.pending)")
                 .font(.system(size: 19, weight: .regular, design: .rounded))
                 .monospacedDigit()
@@ -399,7 +412,6 @@ private struct ActivityRowView: View {
                 .frame(minWidth: 110, alignment: .trailing)
                 .monospacedDigit()
         }
-        .frame(maxWidth: .infinity, alignment: .center)
         .padding(.vertical, 2)
         .contentShape(Rectangle())
         .onTapGesture {


### PR DESCRIPTION
## Summary
- restore name column in Activity rows
- keep Activity header centered and drop the Name heading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a6550a10c8322b10a52d2a43a4dca