### PR TITLE
Fix activity heading alignment

### DIFF
--- a/StudyGroupApp/LifeScoreboardView.swift
+++ b/StudyGroupApp/LifeScoreboardView.swift
@@ -346,9 +346,16 @@ private struct ActivityCard: View {
 
         return ScoreTile(verticalPadding: 8) {
             VStack(alignment: .leading, spacing: 6) {
-                Text("Activity")
-                    .font(.system(size: 21, weight: .bold))
-                    .frame(maxWidth: .infinity, alignment: .center)
+                HStack(spacing: 6) {
+                    // Spacer maintains name column width without a heading
+                    Color.clear
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    // Center the heading over Pending and Projected columns
+                    Text("Activity")
+                        .font(.system(size: 21, weight: .bold))
+                        .frame(minWidth: 190, alignment: .center)
+                }
 
                 HStack(spacing: 6) {
                     // Spacer maintains name column width without a heading


### PR DESCRIPTION
## Summary
- center Activity heading over Pending and Projected columns

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684a670ba1248322ab395c0c4daa6d4f