### PR TITLE
Persist goal name labels to CloudKit

### DIFF
--- a/CloudKitManager.swift
+++ b/CloudKitManager.swift
@@ -10,6 +10,7 @@ class CloudKitManager: ObservableObject {
     private let scoreRecordType = "ScoreRecord"
     private let cardRecordType = "Card"
     private let cardOrderRecordType = "CardOrder"
+    private let goalNameRecordType = "GoalNames"
     private static let userRecordType = "TeamMember"
 
     /// Cached members fetched from CloudKit. Updates to this array reflect
@@ -522,6 +523,29 @@ class CloudKitManager: ObservableObject {
     static func saveCard(_ card: Card) {
         let record = card.toCKRecord()
         CloudKitManager.container.publicCloudDatabase.save(record) { _, _ in }
+    }
+
+    // MARK: - Goal Name Sync
+
+    func fetchGoalNames(completion: @escaping (GoalNames?) -> Void) {
+        let id = CKRecord.ID(recordName: "GoalNames")
+        database.fetch(withRecordID: id) { record, _ in
+            DispatchQueue.main.async {
+                if let record = record, let names = GoalNames(record: record) {
+                    completion(names)
+                } else {
+                    completion(nil)
+                }
+            }
+        }
+    }
+
+    func saveGoalNames(_ names: GoalNames) {
+        let id = CKRecord.ID(recordName: "GoalNames")
+        database.fetch(withRecordID: id) { existing, _ in
+            let record = names.toRecord(existing: existing)
+            self.database.save(record) { _, _ in }
+        }
     }
 
 }

--- a/StudyGroupApp/GoalNames.swift
+++ b/StudyGroupApp/GoalNames.swift
@@ -1,0 +1,35 @@
+import Foundation
+import CloudKit
+
+struct GoalNames: Codable {
+    var id: CKRecord.ID = CKRecord.ID(recordName: "GoalNames")
+    var quotes: String
+    var salesWTD: String
+    var salesMTD: String
+
+    init(quotes: String = "Quotes WTD", salesWTD: String = "Sales WTD", salesMTD: String = "Sales MTD") {
+        self.quotes = quotes
+        self.salesWTD = salesWTD
+        self.salesMTD = salesMTD
+    }
+
+    init?(record: CKRecord) {
+        guard let quotes = record["quotesLabel"] as? String,
+              let salesWTD = record["salesWTDLabel"] as? String,
+              let salesMTD = record["salesMTDLabel"] as? String else {
+            return nil
+        }
+        self.id = record.recordID
+        self.quotes = quotes
+        self.salesWTD = salesWTD
+        self.salesMTD = salesMTD
+    }
+
+    func toRecord(existing: CKRecord? = nil) -> CKRecord {
+        let record = existing ?? CKRecord(recordType: "GoalNames", recordID: id)
+        record["quotesLabel"] = quotes as CKRecordValue
+        record["salesWTDLabel"] = salesWTD as CKRecordValue
+        record["salesMTDLabel"] = salesMTD as CKRecordValue
+        return record
+    }
+}

--- a/StudyGroupApp/WinTheDayView.swift
+++ b/StudyGroupApp/WinTheDayView.swift
@@ -64,11 +64,11 @@ struct WinTheDayView: View {
     @State private var newQuotesGoal = 10
     @State private var newSalesWTDGoal = 2
     @State private var newSalesMTDGoal = 6
-    // Added as per instructions
+    // Goal Name Editor State
     @State private var showGoalNameEditor = false
-    @State private var quotesLabel = "Quotes WTD"
-    @State private var salesWTDLabel = "Sales WTD"
-    @State private var salesMTDLabel = "Sales MTD"
+    @State private var editingQuotesLabel = ""
+    @State private var editingSalesWTDLabel = ""
+    @State private var editingSalesMTDLabel = ""
 
     var body: some View {
         Group {
@@ -82,6 +82,7 @@ struct WinTheDayView: View {
         .onAppear {
             viewModel.fetchMembersFromCloud()
             viewModel.fetchCardsFromCloud()
+            viewModel.fetchGoalNamesFromCloud()
             hasLoaded = true
             shimmerPosition = -1.0
             withAnimation(Animation.linear(duration: 12).repeatForever(autoreverses: false)) {
@@ -131,13 +132,13 @@ struct WinTheDayView: View {
             Text("Edit Goal Names")
                 .font(.headline)
 
-            TextField("Quotes Label", text: $quotesLabel)
+            TextField("Quotes Label", text: $editingQuotesLabel)
                 .textFieldStyle(RoundedBorderTextFieldStyle())
 
-            TextField("Sales WTD Label", text: $salesWTDLabel)
+            TextField("Sales WTD Label", text: $editingSalesWTDLabel)
                 .textFieldStyle(RoundedBorderTextFieldStyle())
 
-            TextField("Sales MTD Label", text: $salesMTDLabel)
+            TextField("Sales MTD Label", text: $editingSalesMTDLabel)
                 .textFieldStyle(RoundedBorderTextFieldStyle())
 
             HStack {
@@ -146,12 +147,22 @@ struct WinTheDayView: View {
                 }
                 Spacer()
                 Button("Save") {
+                    viewModel.saveGoalNames(
+                        quotes: editingQuotesLabel,
+                        salesWTD: editingSalesWTDLabel,
+                        salesMTD: editingSalesMTDLabel
+                    )
                     showGoalNameEditor = false
                 }
             }
             .padding(.top, 10)
         }
         .padding()
+        .onAppear {
+            editingQuotesLabel = viewModel.goalNames.quotes
+            editingSalesWTDLabel = viewModel.goalNames.salesWTD
+            editingSalesMTDLabel = viewModel.goalNames.salesMTD
+        }
     }
 }
 
@@ -277,9 +288,9 @@ private var teamCardsList: some View {
                         },
                         recentlyCompletedIDs: $recentlyCompletedIDs,
                         teamData: $viewModel.teamMembers,
-                        quotesLabel: quotesLabel,
-                        salesWTDLabel: salesWTDLabel,
-                        salesMTDLabel: salesMTDLabel
+                        quotesLabel: viewModel.goalNames.quotes,
+                        salesWTDLabel: viewModel.goalNames.salesWTD,
+                        salesMTDLabel: viewModel.goalNames.salesMTD
                         )
                         .id(member.id)
                     }
@@ -289,6 +300,7 @@ private var teamCardsList: some View {
         }
         .refreshable {
             viewModel.fetchMembersFromCloud()
+            viewModel.fetchGoalNamesFromCloud()
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a new `GoalNames` model to represent label titles
- extend `CloudKitManager` with fetch and save helpers for goal names
- store and sync goal names in `WinTheDayViewModel`
- update `WinTheDayView` to edit and display cloud-synced goal names

## Testing
- `swiftc -parse StudyGroupApp/GoalNames.swift`
- `swiftc -parse CloudKitManager.swift`
- `swiftc -parse StudyGroupApp/WinTheDayViewModel.swift`
- `swiftc -parse StudyGroupApp/WinTheDayView.swift`


------
https://chatgpt.com/codex/tasks/task_e_684b627e2304832281bd746cb9bf2549