### PR TITLE
Fix GoalNames Codable conformance

### DIFF
--- a/StudyGroupApp/GoalNames.swift
+++ b/StudyGroupApp/GoalNames.swift
@@ -2,10 +2,16 @@ import Foundation
 import CloudKit
 
 struct GoalNames: Codable {
+    /// CloudKit record identifier. This value isn't persisted locally so we
+    /// don't attempt to encode/decode it with `Codable`.
     var id: CKRecord.ID = CKRecord.ID(recordName: "GoalNames")
     var quotes: String
     var salesWTD: String
     var salesMTD: String
+
+    private enum CodingKeys: String, CodingKey {
+        case quotes, salesWTD, salesMTD
+    }
 
     init(quotes: String = "Quotes WTD", salesWTD: String = "Sales WTD", salesMTD: String = "Sales MTD") {
         self.quotes = quotes
@@ -31,5 +37,21 @@ struct GoalNames: Codable {
         record["salesWTDLabel"] = salesWTD as CKRecordValue
         record["salesMTDLabel"] = salesMTD as CKRecordValue
         return record
+    }
+
+    // MARK: - Codable
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        quotes = try container.decode(String.self, forKey: .quotes)
+        salesWTD = try container.decode(String.self, forKey: .salesWTD)
+        salesMTD = try container.decode(String.self, forKey: .salesMTD)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(quotes, forKey: .quotes)
+        try container.encode(salesWTD, forKey: .salesWTD)
+        try container.encode(salesMTD, forKey: .salesMTD)
     }
 }


### PR DESCRIPTION
## Summary
- allow GoalNames to encode/decode by providing custom Codable implementation

## Testing
- `swiftc StudyGroupApp/GoalNames.swift -o /tmp/goal_test 2>&1 | head -n 20` *(fails: no such module 'CloudKit')*

------
https://chatgpt.com/codex/tasks/task_e_684b661a66488322b4840006437f34ab