### PR TITLE
Fix local ordering regression

### DIFF
--- a/CloudKitManager.swift
+++ b/CloudKitManager.swift
@@ -73,7 +73,7 @@ class CloudKitManager: ObservableObject {
 
     /// Creates a new ``TeamMember`` record in CloudKit and updates ``teamMembers``.
     func addTeamMember(name: String, emoji: String = "🙂", completion: @escaping (Bool) -> Void = { _ in }) {
-        let member = TeamMember(name: name)
+        var member = TeamMember(name: name)
         member.emoji = emoji
         save(member) { id in
             DispatchQueue.main.async {


### PR DESCRIPTION
## Summary
- revert accidental change making `member` constant when adding new team members

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684b77a2bca4832289d071ef6f2312a7