### PR TITLE
Fix new cards inheriting goals

### DIFF
--- a/CloudKitManager.swift
+++ b/CloudKitManager.swift
@@ -72,8 +72,20 @@ class CloudKitManager: ObservableObject {
     }
 
     /// Creates a new ``TeamMember`` record in CloudKit and updates ``teamMembers``.
+    /// The new member's production goals are initialized to match the existing
+    /// team, if any members are already present.
     func addTeamMember(name: String, emoji: String = "🙂", completion: @escaping (Bool) -> Void = { _ in }) {
         var member = TeamMember(name: name)
+
+        // Mirror the goals of the first existing member so new cards start with
+        // the same targets as the rest of the team. This prevents newly added
+        // cards from defaulting to 1 for each goal.
+        if let template = teamMembers.first {
+            member.quotesGoal = template.quotesGoal
+            member.salesWTDGoal = template.salesWTDGoal
+            member.salesMTDGoal = template.salesMTDGoal
+        }
+
         member.emoji = emoji
         save(member) { id in
             DispatchQueue.main.async {

--- a/StudyGroupApp/UserSelectorView.swift
+++ b/StudyGroupApp/UserSelectorView.swift
@@ -71,8 +71,9 @@ struct UserSelectorView: View {
                                     guard !trimmed.isEmpty, !userManager.userList.contains(trimmed) else { return }
                                     userManager.addUser(trimmed)
                                     CloudKitManager.shared.createScoreRecord(for: trimmed)
-                                    let newMember = TeamMember(name: trimmed)
-                                    cloud.save(newMember) { _ in
+                                    // Use CloudKitManager's helper so the new member
+                                    // inherits existing production goals.
+                                    CloudKitManager.shared.addTeamMember(name: trimmed) { _ in
                                         cloud.fetchTeam { _ in }
                                     }
                                     newUserName = ""


### PR DESCRIPTION
## Summary
- initialize goals for newly added team members using existing values
- call the helper when adding users from the splash screen

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684b7c9476988322b5f6d270e2c03aaf