### PR TITLE
Maintain Win the Day ordering across screens

### DIFF
--- a/StudyGroupApp/WinTheDayViewModel.swift
+++ b/StudyGroupApp/WinTheDayViewModel.swift
@@ -5,6 +5,9 @@ import SwiftUI
 class WinTheDayViewModel: ObservableObject {
     @Published var teamData: [TeamMember] = []
 
+    /// Prevents repeatedly overwriting ``teamData`` when the view reappears.
+    private var hasLoadedCloudKit = false
+
     init() {
         let stored = loadLocalMembers().sorted { $0.sortIndex < $1.sortIndex }
         self.teamMembers = stored
@@ -113,6 +116,9 @@ class WinTheDayViewModel: ObservableObject {
                     if self.lastFetchHash != newHash {
                         self.reorderCards()
                         self.lastFetchHash = newHash
+                        self.teamData = self.teamMembers.sorted { $0.sortIndex < $1.sortIndex }
+                    } else if !self.hasLoadedCloudKit {
+                        self.teamData = self.teamMembers.sorted { $0.sortIndex < $1.sortIndex }
                     }
                 } else {
                     self.teamMembers.sort { $0.sortIndex < $1.sortIndex }
@@ -120,7 +126,10 @@ class WinTheDayViewModel: ObservableObject {
                     self.lastFetchHash = newHash
                     self.initializeResetDatesIfNeeded()
                     self.hasFetchedMembers = true
+                    self.teamData = self.teamMembers.sorted { $0.sortIndex < $1.sortIndex }
                 }
+
+                self.hasLoadedCloudKit = true
 
                 self.performResetsIfNeeded()
                 self.saveLocal()


### PR DESCRIPTION
## Summary
- avoid overwriting Win the Day data on every appear
- populate `teamData` only when CloudKit data changes

## Testing
- `swift -version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684f16956a58832281c9172fe9a181ce