### PR TITLE
Fix sorting sync in WinTheDayViewModel

### DIFF
--- a/StudyGroupApp/WinTheDayViewModel.swift
+++ b/StudyGroupApp/WinTheDayViewModel.swift
@@ -46,6 +46,7 @@ class WinTheDayViewModel: ObservableObject {
             hasher.combine(m.quotesToday)
             hasher.combine(m.salesWTD)
             hasher.combine(m.salesMTD)
+            hasher.combine(m.quotesGoal)
         }
         return hasher.finalize()
     }
@@ -102,7 +103,6 @@ class WinTheDayViewModel: ObservableObject {
             let sorted = fetched.sorted { $0.quotesGoal > $1.quotesGoal }
             let newHash = self.computeHash(for: sorted)
 
-            // Ensure all local entries exist
             self.updateLocalEntries(names: sorted.map { $0.name })
 
             for member in sorted {
@@ -117,7 +117,7 @@ class WinTheDayViewModel: ObservableObject {
                 }
             }
 
-            if self.lastFetchHash != newHash || !self.isLoaded {
+            if self.lastFetchHash != newHash {
                 self.teamMembers = sorted
                 for idx in self.teamMembers.indices { self.teamMembers[idx].sortIndex = idx }
                 self.displayedMembers = self.teamMembers
@@ -190,21 +190,14 @@ class WinTheDayViewModel: ObservableObject {
         teamMembers.removeAll { member in !names.contains(member.name) }
 
         let stored = loadLocalMembers()
-        var maxIndex = teamMembers.map { $0.sortIndex }.max() ?? -1
 
         for name in names where !teamMembers.contains(where: { $0.name == name }) {
             if let saved = stored.first(where: { $0.name == name }) {
                 teamMembers.append(saved)
-                maxIndex = max(maxIndex, saved.sortIndex)
             } else {
-                var newMember = TeamMember(name: name)
-                maxIndex += 1
-                newMember.sortIndex = maxIndex
-                teamMembers.append(newMember)
+                teamMembers.append(TeamMember(name: name))
             }
         }
-
-        teamMembers.sort { $0.sortIndex < $1.sortIndex }
     }
 
     func load(names: [String], completion: (() -> Void)? = nil) {


### PR DESCRIPTION
## Summary
- sort WinTheDayViewModel data only after CloudKit finishes fetching
- include goal data in the fetch hash
- prevent local fallback order from affecting CloudKit order

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684f20ea091c8322b68ccd7bae56bde7