### PR TITLE
Fix WinTheDay team ordering

### DIFF
--- a/StudyGroupApp/WinTheDayViewModel.swift
+++ b/StudyGroupApp/WinTheDayViewModel.swift
@@ -97,10 +97,10 @@ class WinTheDayViewModel: ObservableObject {
     /// Ordering mirrors ``LifeScoreboardViewModel`` so cards remain stable
     /// between view loads.
     func fetchMembersFromCloud(completion: (() -> Void)? = nil) {
-        CloudKitManager.shared.fetchAllTeamMembers { [weak self] fetched in
+        CloudKitManager.shared.fetchAllTeamMembers { [weak self] fetchedTeam in
             guard let self = self else { return }
 
-            let sorted = fetched.sorted { $0.quotesGoal > $1.quotesGoal }
+            let sorted = fetchedTeam.sorted { $0.quotesGoal > $1.quotesGoal }
             let newHash = self.computeHash(for: sorted)
 
             self.updateLocalEntries(names: sorted.map { $0.name })
@@ -128,8 +128,18 @@ class WinTheDayViewModel: ObservableObject {
             }
 
             self.performResetsIfNeeded()
-            self.isLoaded = true
-            completion?()
+
+            DispatchQueue.main.async {
+                print("🔄 Reordering teamData based on CloudKit data")
+                self.teamData = fetchedTeam.sorted { $0.quotesGoal > $1.quotesGoal }
+                self.isLoaded = true
+
+                for member in self.teamData {
+                    print("➡️ \(member.name): \(member.quotesGoal)")
+                }
+
+                completion?()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure `teamData` only sorts after CloudKit fetch
- print debugging info when sorting

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_684f232d28e0832295d211ffb3397af7