### PR TITLE
Fix Save action reordering

### DIFF
--- a/StudyGroupApp/WinTheDayViewModel.swift
+++ b/StudyGroupApp/WinTheDayViewModel.swift
@@ -159,7 +159,21 @@ class WinTheDayViewModel: ObservableObject {
     func saveEdits(for member: TeamMember) {
         withAnimation { reorderAfterSave() }
         saveLocal()
-        saveMember(member) { _ in }
+        saveMember(member) { _ in
+            DispatchQueue.main.async {
+                self.teamData.sort {
+                    let scoreA = $0.quotesToday + $0.salesWTD + $0.salesMTD
+                    let scoreB = $1.quotesToday + $1.salesWTD + $1.salesMTD
+                    return scoreA > scoreB
+                }
+
+                print("🔄 Re-sorted after Save:")
+                for member in self.teamData {
+                    let total = member.quotesToday + member.salesWTD + member.salesMTD
+                    print("➡️ \(member.name): \(total)")
+                }
+            }
+        }
     }
 
     private func saveLocal() {


### PR DESCRIPTION
## Summary
- fix the save routine so saving a member triggers immediate re-sort of `teamData`

## Testing
- `swiftc --version`
- `swiftformat --version` *(fails: command not found)*
- `swiftlint version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2644a4388322a98aeb0f25381d85