### PR TITLE
Fix card reorder after save

### DIFF
--- a/StudyGroupApp/WinTheDayView.swift
+++ b/StudyGroupApp/WinTheDayView.swift
@@ -260,7 +260,7 @@ private var teamCardsList: some View {
     ScrollViewReader { scrollProxy in
         ScrollView {
             VStack(spacing: 10) {
-
+                
                 ForEach(viewModel.teamData, id: \.id) { member in
                     if let idx = viewModel.teamMembers.firstIndex(where: { $0.id == member.id }) {
                         let name = viewModel.teamMembers[idx].name
@@ -295,6 +295,7 @@ private var teamCardsList: some View {
                 }
             }
             .padding(.horizontal, 20)
+            .animation(.easeInOut, value: viewModel.teamData.map { $0.id })
         }
         .refreshable {
             viewModel.fetchMembersFromCloud()

--- a/StudyGroupApp/WinTheDayViewModel.swift
+++ b/StudyGroupApp/WinTheDayViewModel.swift
@@ -71,9 +71,11 @@ class WinTheDayViewModel: ObservableObject {
         }
     }
 
-    /// Reorders ``displayedCards`` after the user saves edits.
+    /// Reorders cards and updates ``teamData`` after the user saves edits.
+    /// This keeps the visible list in sync with the latest production values.
     func reorderAfterSave() {
         reorderCards()
+        teamData = teamMembers
     }
 
     // MARK: - Card Sync Helpers


### PR DESCRIPTION
## Summary
- ensure card list is sorted and animated right after saving edits
- restore card list animation on data changes

## Testing
- `swift --version`
- `swift build` *(fails: no Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684f2a255ac88322aef10cde9e03fae9