### PR TITLE
Fix TeamMember compile error by removing unused fields

### DIFF
--- a/StudyGroupApp/TeamMember.swift
+++ b/StudyGroupApp/TeamMember.swift
@@ -169,17 +169,13 @@ extension TeamMember {
 
         record["name"] = name as CKRecordValue
         record["emoji"] = emoji as CKRecordValue
-        record["pending"] = pending as CKRecordValue
-        record["projected"] = projected as CKRecordValue
         record["quotesGoal"] = quotesGoal as CKRecordValue
         record["quotesToday"] = quotesToday as CKRecordValue
         record["salesMTD"] = salesMTD as CKRecordValue
         record["salesMTDGoal"] = salesMTDGoal as CKRecordValue
         record["salesWTD"] = salesWTD as CKRecordValue
         record["salesWTDGoal"] = salesWTDGoal as CKRecordValue
-        record["score"] = score as CKRecordValue
         record["sortIndex"] = sortIndex as CKRecordValue
-        record["testFlag"] = testFlag as CKRecordValue
 
         return record
     }


### PR DESCRIPTION
## Summary
- remove scoreboard property references from `TeamMember.toRecord`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68522131ebd0832294699d4d487271ef