### PR TITLE
Fix team member sync to match by name

### DIFF
--- a/CloudKitManager.swift
+++ b/CloudKitManager.swift
@@ -143,13 +143,8 @@ class CloudKitManager: ObservableObject {
     }
 
     private func prepareModifyOperation(for member: TeamMember, existingRecord: CKRecord?, completion: @escaping (CKRecord.ID?) -> Void) -> CKModifyRecordsOperation {
-        let newRecord = member.toRecord()
-        var recordIDsToDelete: [CKRecord.ID]? = nil
-        if let existing = existingRecord, existing.recordID.recordName != member.name {
-            recordIDsToDelete = [existing.recordID]
-        }
-
-        let modifyOperation = CKModifyRecordsOperation(recordsToSave: [newRecord], recordIDsToDelete: recordIDsToDelete)
+        let record = member.toRecord(existing: existingRecord)
+        let modifyOperation = CKModifyRecordsOperation(recordsToSave: [record], recordIDsToDelete: nil)
         modifyOperation.modifyRecordsResultBlock = { result in
             DispatchQueue.main.async {
                 switch result {
@@ -158,7 +153,7 @@ class CloudKitManager: ObservableObject {
                     completion(nil)
                 case .success:
                     print("✅ Successfully saved member: \(member.name)")
-                    completion(newRecord.recordID)
+                    completion(record.recordID)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- prevent duplicate TeamMember records by reusing existing CloudKit IDs
- modify team member save logic to always use the name-based record when creating new entries

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685224c623bc832296d9267f2e6ae17e