### PR TITLE
Fix CloudKit query API usage

### DIFF
--- a/Outcast/WinTheDayViewModel.swift
+++ b/Outcast/WinTheDayViewModel.swift
@@ -42,19 +42,35 @@ class WinTheDayViewModel: ObservableObject {
 
     func fetchTeamMembers() {
         let query = CKQuery(recordType: "TeamMember", predicate: NSPredicate(value: true))
-        database.perform(query, inZoneWith: nil) { records, error in
-            if let records = records {
+        database.fetch(withQuery: query,
+                       inZoneWith: nil,
+                       desiredKeys: nil,
+                       resultsLimit: CKQueryOperation.maximumResults) { result in
+            switch result {
+            case .success(let (matchResults, _)):
+                let records = matchResults.compactMap { _, recordResult in
+                    try? recordResult.get()
+                }
                 DispatchQueue.main.async {
                     self.teamData = records.compactMap { TeamMember(record: $0) }
                 }
+            case .failure:
+                break
             }
         }
     }
 
     func wipeAndResetCloudKit() {
         let query = CKQuery(recordType: "TeamMember", predicate: NSPredicate(value: true))
-        database.perform(query, inZoneWith: nil) { records, error in
-            if let records = records {
+        database.fetch(withQuery: query,
+                       inZoneWith: nil,
+                       desiredKeys: nil,
+                       resultsLimit: CKQueryOperation.maximumResults) { result in
+            switch result {
+            case .success(let (matchResults, _)):
+                let records = matchResults.compactMap { _, recordResult in
+                    try? recordResult.get()
+                }
                 let operations = records.map { CKModifyRecordsOperation(recordsToSave: nil, recordIDsToDelete: [$0.recordID]) }
                 let operationQueue = OperationQueue()
                 operationQueue.addOperations(operations, waitUntilFinished: true)
@@ -63,6 +79,8 @@ class WinTheDayViewModel: ObservableObject {
                     self.teamData.removeAll()
                     // Add any default team members or reset logic here
                 }
+            case .failure:
+                break
             }
         }
     }


### PR DESCRIPTION
## Summary
- modernize CloudKit fetch calls in scoreboard and Outcast view models
- remove deprecated `perform(_:inZoneWith:)` usage

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68570c18ed708322b6f2a130a436a31f