### PR TITLE
Fix repeated team fetches

### DIFF
--- a/CloudKitManager.swift
+++ b/CloudKitManager.swift
@@ -480,6 +480,26 @@ class CloudKitManager: ObservableObject {
         }
     }
 
+    /// Fetches all user names stored in CloudKit without filtering by name.
+    static func fetchAllUserNames(completion: @escaping ([String]) -> Void) {
+        print("🕒 \(Date()) — \u{1F50D} Starting fetchAllUserNames()")
+        let query = CKQuery(recordType: userRecordType, predicate: NSPredicate(value: true))
+        CloudKitManager.container.publicCloudDatabase.fetch(withQuery: query, inZoneWith: nil, desiredKeys: ["name"], resultsLimit: CKQueryOperation.maximumResults) { result in
+            switch result {
+            case .success(let (matchResults, _)):
+                let records = matchResults.compactMap { _, recordResult in
+                    try? recordResult.get()
+                }
+                let names = records.compactMap { $0["name"] as? String }
+                print("🕒 \(Date()) — ✅ fetchAllUserNames() loaded \(names.count) users")
+                completion(names.sorted())
+            case .failure(let error):
+                print("🕒 \(Date()) — ❌ fetchAllUserNames() failed: \(error.localizedDescription)")
+                completion([])
+            }
+        }
+    }
+
     /// Convenience wrapper that uses ``UserManager``'s current user.
     /// Calls ``fetchUsers(for:completion:)`` and simply prints the results.
     func fetchUsers() {

--- a/StudyGroupApp/UserManager.swift
+++ b/StudyGroupApp/UserManager.swift
@@ -80,7 +80,7 @@ class UserManager: ObservableObject {
     }
 
     func fetchUsersFromCloud() {
-        CloudKitManager.fetchUsers(for: currentUser) { names in
+        CloudKitManager.fetchAllUserNames { names in
             DispatchQueue.main.async {
                 print("📥 Received users from CloudKit: \(names)")
                 self.userList = names

--- a/StudyGroupApp/UserSelectorView.swift
+++ b/StudyGroupApp/UserSelectorView.swift
@@ -93,10 +93,6 @@ struct UserSelectorView: View {
                     .frame(height: geometry.size.height)
                 }
             }
-            .onAppear {
-                userManager.fetchUsersFromCloud()
-                viewModel.fetchTeam()
-            }
         }
     }
 


### PR DESCRIPTION
## Summary
- added a helper to load all user names from CloudKit
- updated `UserManager` to use new helper
- removed extra splash-screen fetch to avoid double loads

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6857627def54832290082655b32faf6e