### PR TITLE
Allow zero goal members

### DIFF
--- a/CloudKitManager.swift
+++ b/CloudKitManager.swift
@@ -18,10 +18,7 @@ class CloudKitManager: ObservableObject {
     @Published var teamMembers: [TeamMember] = []
 
     private func isValid(_ member: TeamMember) -> Bool {
-        !member.name.trimmingCharacters(in: .whitespaces).isEmpty &&
-        member.quotesGoal > 0 &&
-        member.salesWTDGoal > 0 &&
-        member.salesMTDGoal > 0
+        !member.name.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
     func fetchTeam(completion: @escaping ([TeamMember]) -> Void) {

--- a/StudyGroupApp/TeamMember.swift
+++ b/StudyGroupApp/TeamMember.swift
@@ -168,19 +168,17 @@ extension TeamMember {
     static let recordType = "TeamMember"
 
     convenience init?(record: CKRecord) {
-        guard
-            let name = record["name"] as? String,
-            !name.isEmpty,
-            let quotesToday = record["quotesToday"] as? Int,
-            let salesWTD = record["salesWTD"] as? Int,
-            let salesMTD = record["salesMTD"] as? Int,
-            let quotesGoal = record["quotesGoal"] as? Int,
-            let salesWTDGoal = record["salesWTDGoal"] as? Int,
-            let salesMTDGoal = record["salesMTDGoal"] as? Int,
-            let emoji = record["emoji"] as? String
-        else {
+        guard let name = record["name"] as? String, !name.isEmpty else {
             return nil
         }
+
+        let quotesToday = record["quotesToday"] as? Int ?? 0
+        let salesWTD = record["salesWTD"] as? Int ?? 0
+        let salesMTD = record["salesMTD"] as? Int ?? 0
+        let quotesGoal = record["quotesGoal"] as? Int ?? 0
+        let salesWTDGoal = record["salesWTDGoal"] as? Int ?? 0
+        let salesMTDGoal = record["salesMTDGoal"] as? Int ?? 0
+        let emoji = record["emoji"] as? String ?? "🙂"
 
         let pending = record["pending"] as? Int ?? 0
         let projected = record["projected"] as? Double ?? 0.0


### PR DESCRIPTION
## Summary
- relax member validation to allow zero goal values
- default goal fields to 0 when loading TeamMember records

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857669629ec832294166d977a1a686d