### PR TITLE
Fix CloudKit record ID collisions

### DIFF
--- a/StudyGroupApp/CardModel.swift
+++ b/StudyGroupApp/CardModel.swift
@@ -25,7 +25,7 @@ struct CardModel: Identifiable {
     }
 
     func toRecord() -> CKRecord {
-        let record = CKRecord(recordType: "CardModel", recordID: CKRecord.ID(recordName: userName))
+        let record = CKRecord(recordType: "CardModel", recordID: CKRecord.ID(recordName: "card-\(userName)"))
         record["userName"] = userName as CKRecordValue
         record["emoji"] = emoji as CKRecordValue
         record["goal1"] = goal1 as CKRecordValue

--- a/StudyGroupApp/LifeScoreboardViewModel.swift
+++ b/StudyGroupApp/LifeScoreboardViewModel.swift
@@ -424,7 +424,7 @@ class LifeScoreboardViewModel: ObservableObject {
                 for member in self.teamMembers {
                     guard !member.name.trimmingCharacters(in: .whitespaces).isEmpty else { continue }
 
-                    let recordID = CKRecord.ID(recordName: member.name)
+                    let recordID = CKRecord.ID(recordName: "member-\(member.name)")
                     let record = CKRecord(recordType: "TeamMember", recordID: recordID)
                     record["name"] = member.name as CKRecordValue
                     record["emoji"] = member.emoji as CKRecordValue

--- a/StudyGroupApp/TeamMember.swift
+++ b/StudyGroupApp/TeamMember.swift
@@ -206,7 +206,7 @@ extension TeamMember {
     func toRecord(existing: CKRecord? = nil) -> CKRecord {
         let record = existing ?? CKRecord(
             recordType: "TeamMember",
-            recordID: CKRecord.ID(recordName: self.name)
+            recordID: CKRecord.ID(recordName: "member-\(self.name)")
         )
         record["name"] = self.name
         record["emoji"] = self.emoji


### PR DESCRIPTION
## Summary
- prevent cross-type record name conflicts by prefixing IDs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857697545c883228ca2220b380daed3