### PR TITLE
Fix state loss when entering main tabs

### DIFF
--- a/StudyGroupApp/MainTabView.swift
+++ b/StudyGroupApp/MainTabView.swift
@@ -10,12 +10,15 @@ import SwiftUI
 
 struct MainTabView: View {
     @EnvironmentObject var userManager: UserManager
+    /// Shared WinTheDayViewModel passed from the splash screen so card state
+    /// persists when entering the main tabs.
+    @EnvironmentObject var viewModel: WinTheDayViewModel
     init() {
         UITabBar.appearance().backgroundColor = UIColor.systemGray6
     }
     var body: some View {
         TabView {
-            WinTheDayView(viewModel: WinTheDayViewModel())
+            WinTheDayView(viewModel: viewModel)
                 .tabItem {
                     Image(systemName: "checkmark.seal.fill")
                     Text("Win the Day")


### PR DESCRIPTION
## Summary
- keep the WinTheDayViewModel from the splash screen when showing the tab interface

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68576f3c82d883229404bfa716be30ea