### PR TITLE
Fix progress bar when goals are zero

### DIFF
--- a/StudyGroupApp/WinTheDayView.swift
+++ b/StudyGroupApp/WinTheDayView.swift
@@ -530,7 +530,7 @@ struct StatRow: View {
                 Capsule()
                     .fill(progressColor(for: type, value: value, goal: goal))
                     .frame(
-                        width: min(CGFloat(value) / CGFloat(goal), 1.0) * 140,
+                        width: goal > 0 ? min(CGFloat(value) / CGFloat(goal), 1.0) * 140 : 0,
                         height: 10
                     )
                     .padding(.leading, 10)


### PR DESCRIPTION
## Summary
- avoid division by zero for production bars in WinTheDay

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68577449a3308322ace95439b8e79ded