### PR TITLE
Fix WinTheDay card syncing

### DIFF
--- a/StudyGroupApp/Card.swift
+++ b/StudyGroupApp/Card.swift
@@ -6,12 +6,15 @@ struct Card: Identifiable, Hashable {
     var name: String
     var emoji: String
     var production: Int
+    /// Determines display order when loading from CloudKit
+    var orderIndex: Int
 
-    init(id: String = UUID().uuidString, name: String, emoji: String = "", production: Int = 0) {
+    init(id: String = UUID().uuidString, name: String, emoji: String = "", production: Int = 0, orderIndex: Int = 0) {
         self.id = id
         self.name = name
         self.emoji = emoji
         self.production = production
+        self.orderIndex = orderIndex
     }
 
     init?(record: CKRecord) {
@@ -20,10 +23,12 @@ struct Card: Identifiable, Hashable {
               let production = record["production"] as? Int else {
             return nil
         }
+        let orderIndex = record["orderIndex"] as? Int ?? 0
         self.id = record.recordID.recordName
         self.name = name
         self.emoji = emoji
         self.production = production
+        self.orderIndex = orderIndex
     }
 
     func toCKRecord(existing: CKRecord? = nil) -> CKRecord {
@@ -31,6 +36,7 @@ struct Card: Identifiable, Hashable {
         record["name"] = name as CKRecordValue
         record["emoji"] = emoji as CKRecordValue
         record["production"] = production as CKRecordValue
+        record["orderIndex"] = orderIndex as CKRecordValue
         return record
     }
 }

--- a/StudyGroupApp/WinTheDayViewModel.swift
+++ b/StudyGroupApp/WinTheDayViewModel.swift
@@ -27,6 +27,8 @@ class WinTheDayViewModel: ObservableObject {
     @Published var displayedCards: [Card] = []
     @Published var selectedUserName: String = ""
     @Published var goalNames: GoalNames = GoalNames()
+    /// Indicates whether a card sync operation is in progress
+    @Published var isLoading: Bool = false
     private let storageKey = "WTDMemberStorage"
     private static let goalNameKey = "WTDGoalNames"
     private var hasLoadedDisplayOrder = false
@@ -81,10 +83,36 @@ class WinTheDayViewModel: ObservableObject {
     // MARK: - Card Sync Helpers
 
     func fetchCardsFromCloud() {
-        CloudKitManager.fetchCards { fetched in
+        guard !selectedUserName.isEmpty else {
+            print("❌ fetchCardsFromCloud failed: selectedUserName is empty")
+            return
+        }
+
+        isLoading = true
+        let predicate = NSPredicate(format: "user == %@", selectedUserName)
+        let query = CKQuery(recordType: "Card", predicate: predicate)
+
+        CloudKitManager.container.publicCloudDatabase.fetch(
+            withQuery: query,
+            inZoneWith: nil,
+            desiredKeys: nil,
+            resultsLimit: CKQueryOperation.maximumResults
+        ) { result in
             DispatchQueue.main.async {
-                self.cards = fetched
-                self.displayedCards = fetched.sorted { $0.production > $1.production }
+                self.isLoading = false
+                switch result {
+                case .success(let (matchResults, _)):
+                    let records = matchResults.compactMap { _, r in try? r.get() }
+                    let fetchedCards = records.compactMap { Card(record: $0) }
+                    print("✅ Loaded \(fetchedCards.count) cards for user: \(self.selectedUserName)")
+                    self.cards = fetchedCards.sorted { $0.orderIndex < $1.orderIndex }
+                    self.displayedCards = self.cards
+
+                case .failure(let error):
+                    print("❌ Error fetching cards: \(error.localizedDescription)")
+                    self.cards = []
+                    self.displayedCards = []
+                }
             }
         }
     }
@@ -183,6 +211,7 @@ class WinTheDayViewModel: ObservableObject {
                 }
 
                 self.isLoaded = true
+                self.fetchCardsFromCloud()
                 completion?()
             }
         }


### PR DESCRIPTION
## Summary
- add `orderIndex` field to `Card`
- restore CloudKit `fetchCardsFromCloud` logic and call it after fetching team members
- expose loading state via `isLoading`

## Testing
- `swiftc -c StudyGroupApp/*.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685856943bcc8322a95088cff544c3fd