### PR TITLE
Fix WinTheDay cards showing for all users

### DIFF
--- a/StudyGroupApp/WinTheDayView.swift
+++ b/StudyGroupApp/WinTheDayView.swift
@@ -82,6 +82,7 @@ struct WinTheDayView: View {
             viewModel.fetchMembersFromCloud()
             viewModel.fetchCardsFromCloud()
             viewModel.fetchGoalNamesFromCloud()
+            viewModel.ensureCardsForAllUsers(userManager.userList)
             shimmerPosition = -1.0
             withAnimation(Animation.linear(duration: 12).repeatForever(autoreverses: false)) {
                 shimmerPosition = 1.5
@@ -92,6 +93,7 @@ struct WinTheDayView: View {
         if viewModel.isLoaded {
             viewModel.fetchMembersFromCloud()
         }
+        viewModel.ensureCardsForAllUsers(userManager.userList)
     }
     .sheet(isPresented: $emojiPickerVisible) {
         emojiPickerSheet
@@ -300,6 +302,7 @@ private var teamCardsList: some View {
         .refreshable {
             viewModel.fetchMembersFromCloud()
             viewModel.fetchGoalNamesFromCloud()
+            viewModel.ensureCardsForAllUsers(userManager.userList)
         }
     }
 }


### PR DESCRIPTION
## Summary
- add persistent card storage helpers and ensureCardsForAllUsers to WinTheDayViewModel
- load stored cards on launch and call ensureCardsForAllUsers after CloudKit fetch
- keep UI updated by calling ensureCardsForAllUsers from WinTheDayView

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_685875de789c8322bd1b9dca814e7098