### PR TITLE
Fix JSON encoding for Card struct

### DIFF
--- a/StudyGroupApp/Card.swift
+++ b/StudyGroupApp/Card.swift
@@ -1,7 +1,9 @@
 import CloudKit
 import Foundation
 
-struct Card: Identifiable, Hashable {
+/// Represents a single Win the Day card. The type conforms to `Codable`
+/// so it can be persisted with `JSONEncoder`/`JSONDecoder`.
+struct Card: Identifiable, Hashable, Codable {
     var id: String
     var name: String
     var emoji: String


### PR DESCRIPTION
## Summary
- make `Card` conform to `Codable` so cards can be stored with `JSONEncoder`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68587d1415608322a30f80e4aa65d318