### PR TITLE
Fix card caching key

### DIFF
--- a/StudyGroupApp/WinTheDayViewModel.swift
+++ b/StudyGroupApp/WinTheDayViewModel.swift
@@ -130,7 +130,7 @@ class WinTheDayViewModel: ObservableObject {
     }
 
     private func loadLocalCards() {
-        if let data = UserDefaults.standard.data(forKey: "cachedCards"),
+        if let data = UserDefaults.standard.data(forKey: cardsStorageKey),
            let cached = try? JSONDecoder().decode([Card].self, from: data) {
             DispatchQueue.main.async {
                 self.cards = cached.sorted(by: { $0.orderIndex < $1.orderIndex })
@@ -143,7 +143,7 @@ class WinTheDayViewModel: ObservableObject {
 
     private func saveCardsToLocal() {
         if let data = try? JSONEncoder().encode(cards) {
-            UserDefaults.standard.set(data, forKey: "cachedCards")
+            UserDefaults.standard.set(data, forKey: cardsStorageKey)
             print("✅ Cards saved to local cache.")
         }
     }


### PR DESCRIPTION
## Summary
- fix mismatch between cache keys for Win the Day cards so they persist locally

## Testing
- `swiftc --version`
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68587e9f5eb88322a600b30f8e216b12