### PR TITLE
Fix card initialization for CloudKit

### DIFF
--- a/StudyGroupApp/UserManager.swift
+++ b/StudyGroupApp/UserManager.swift
@@ -56,9 +56,15 @@ class UserManager: ObservableObject {
     func addUser(_ name: String) {
         guard !userList.contains(name) else { return }
         CloudKitManager.saveUser(name) { [weak self] in
-            // Create a default Win the Day card for the new user
-            let defaultCard = CardModel(userName: name)
-            CloudKitManager.shared.save(card: defaultCard)
+            // Create a default Win the Day card so the record type exists
+            let defaultCard = Card(
+                id: "card-\(name)",
+                name: name,
+                emoji: "\u{2728}",
+                production: 0,
+                orderIndex: 0
+            )
+            CloudKitManager.saveCard(defaultCard)
             self?.fetchUsersFromCloud()
         }
     }

--- a/StudyGroupApp/WinTheDayViewModel.swift
+++ b/StudyGroupApp/WinTheDayViewModel.swift
@@ -480,12 +480,15 @@ class WinTheDayViewModel: ObservableObject {
 
     /// Ensures a placeholder card exists for each provided user name.
     /// Local cards are persisted so the UI can appear immediately before
-    /// CloudKit records sync down.
+    /// CloudKit records sync down. Any newly created cards are also
+    /// uploaded to CloudKit using a stable record ID to initialize the
+    /// `Card` record type if needed.
     func ensureCardsForAllUsers(_ users: [String]) {
-        for name in users {
+        for (index, name) in users.enumerated() {
             if !cards.contains(where: { $0.name == name }) {
-                let card = Card(name: name, emoji: "\u{2728}")
+                let card = Card(id: "card-\(name)", name: name, emoji: "\u{2728}", orderIndex: index)
                 cards.append(card)
+                CloudKitManager.saveCard(card)
             }
         }
         saveCardsToDevice()


### PR DESCRIPTION
## Summary
- create a default `Card` when adding a new user so the `Card` record type is saved to CloudKit
- seed CloudKit with cards for all users the first time `ensureCardsForAllUsers` runs

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68587f7a91f083229907d73b9e7c02ff