### PR TITLE
Add pull-to-refresh on splash screen

### DIFF
--- a/StudyGroupApp/UserManager.swift
+++ b/StudyGroupApp/UserManager.swift
@@ -89,11 +89,14 @@ class UserManager: ObservableObject {
         CloudKitManager.fetchAllUserNames { names in
             DispatchQueue.main.async {
                 print("📥 Received users from CloudKit: \(names)")
-                self.userList = names
-                self.allUsers = names
-                self.saveUsers()
-                if !names.contains(self.currentUser) {
-                    self.currentUser = names.first ?? ""
+                let sorted = names
+                if sorted != self.userList {
+                    self.userList = sorted
+                    self.allUsers = sorted
+                    self.saveUsers()
+                }
+                if !sorted.contains(self.currentUser) {
+                    self.currentUser = sorted.first ?? ""
                 }
             }
         }

--- a/StudyGroupApp/UserSelectorView.swift
+++ b/StudyGroupApp/UserSelectorView.swift
@@ -65,6 +65,10 @@ struct UserSelectorView: View {
                                 .padding(.top, 24)
                             }
                             .listStyle(PlainListStyle())
+                            .refreshable {
+                                userManager.refresh()
+                                viewModel.fetchMembersFromCloud()
+                            }
                             .alert("Add User", isPresented: $showAddUserAlert) {
                                 TextField("Name", text: $newUserName)
                                 Button("Add", action: {


### PR DESCRIPTION
## Summary
- add refresh trigger to the user selector list
- avoid overwriting local users if CloudKit data matches

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858921a58848322ad54d5bb90e19f50