### PR TITLE
Fix scoreboard CloudKit save

### DIFF
--- a/StudyGroupApp/LifeScoreboardViewModel.swift
+++ b/StudyGroupApp/LifeScoreboardViewModel.swift
@@ -277,14 +277,16 @@ class LifeScoreboardViewModel: ObservableObject {
         reorderLocal()
         saveLocal()
 
+        let container = CloudKitManager.container
         let recordID = CKRecord.ID(recordName: "score-\(entry.name)")
+
         container.publicCloudDatabase.fetch(withRecordID: recordID) { existingRecord, _ in
             if let record = existingRecord {
                 record["actual"] = entry.score as CKRecordValue
                 record["pending"] = pending as CKRecordValue
                 record["projected"] = projected as CKRecordValue
 
-                self.container.publicCloudDatabase.save(record) { savedRecord, error in
+                container.publicCloudDatabase.save(record) { savedRecord, error in
                     if let error = error {
                         print("❌ Error saving updated score record: \(error)")
                     } else {


### PR DESCRIPTION
## Summary
- call WinTheDay-style local CloudKit save method in `save(_:pending:projected:)`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68589f9048c08322abd0c67c11ebd622