### PR TITLE
Fix CloudKit score save compile error

### DIFF
--- a/CloudKitManager.swift
+++ b/CloudKitManager.swift
@@ -315,7 +315,9 @@ class CloudKitManager: ObservableObject {
         let recordID = CKRecord.ID(recordName: "score-\(entry.name)")
         let record = CKRecord(recordType: "Score", recordID: recordID)
         record["name"] = entry.name as CKRecordValue
-        record["actual"] = entry.actual as CKRecordValue
+        // `ScoreEntry` doesn't store an `actual` field, so use its `score`
+        // when updating the CloudKit record.
+        record["actual"] = entry.score as CKRecordValue
         record["pending"] = pending as CKRecordValue
         record["projected"] = projected as CKRecordValue
         self.database.save(record) { _, error in


### PR DESCRIPTION
## Summary
- fix saveScore in CloudKitManager to use `entry.score` instead of `entry.actual`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858a104ddc8832296006d00bcf1edb4