### PR TITLE
Revert sandboxed scoreboard changes

### DIFF
--- a/CloudKitManager.swift
+++ b/CloudKitManager.swift
@@ -109,35 +109,6 @@ class CloudKitManager: ObservableObject {
         }
     }
 
-    /// Creates paired Win the Day and Life Scoreboard records for the provided name.
-    /// Only the fields relevant to each feature are included so data stays sandboxed.
-    func createTeamMemberRecords(for name: String) {
-        // WIN THE DAY record
-        let winRecord = CKRecord(recordType: recordType)
-        winRecord["name"] = name as CKRecordValue
-        winRecord["emoji"] = "🙂" as CKRecordValue
-        winRecord["actual"] = 0 as CKRecordValue
-
-        // LIFE SCOREBOARD record
-        let scoreboardRecord = CKRecord(recordType: recordType)
-        scoreboardRecord["name"] = name as CKRecordValue
-        scoreboardRecord["pending"] = 0 as CKRecordValue
-        scoreboardRecord["projected"] = 0 as CKRecordValue
-        scoreboardRecord["actual"] = 0 as CKRecordValue
-
-        let saveOp = CKModifyRecordsOperation(recordsToSave: [winRecord, scoreboardRecord])
-        saveOp.savePolicy = .allKeys
-        saveOp.modifyRecordsCompletionBlock = { _, _, error in
-            if let error = error {
-                print("❌ Failed to save team member records: \(error)")
-            } else {
-                print("✅ Created Win + Scoreboard records for \(name)")
-            }
-        }
-
-        CKContainer.default().publicCloudDatabase.add(saveOp)
-    }
-
     /// Deletes the provided ``TeamMember`` from CloudKit and local cache.
     func deleteTeamMember(_ member: TeamMember, completion: @escaping (Bool) -> Void = { _ in }) {
         delete(member)

--- a/StudyGroupApp/LifeScoreboardViewModel.swift
+++ b/StudyGroupApp/LifeScoreboardViewModel.swift
@@ -315,34 +315,6 @@ class LifeScoreboardViewModel: ObservableObject {
         }
     }
 
-    /// Loads only `TeamMember` records containing Life Scoreboard fields.
-    private func fetchScoreboardMembers(completion: @escaping ([TeamMember]) -> Void) {
-        let predicate = NSPredicate(format: "pending >= 0 OR projected >= 0")
-        let query = CKQuery(recordType: "TeamMember", predicate: predicate)
-        let operation = CKQueryOperation(query: query)
-
-        var results: [TeamMember] = []
-
-        operation.recordFetchedBlock = { record in
-            let name = record["name"] as? String ?? "Unknown"
-            let pending = record["pending"] as? Int ?? 0
-            let projected = record["projected"] as? Double ?? 0
-            let actual = record["actual"] as? Int ?? 0
-
-            let member = TeamMember(name: name)
-            member.pending = pending
-            member.projected = projected
-            member.actual = actual
-            results.append(member)
-        }
-
-        operation.queryCompletionBlock = { _ in
-            DispatchQueue.main.async { completion(results) }
-        }
-
-        container.publicCloudDatabase.add(operation)
-    }
-
     /// Ensures all `TeamMember` records contain Life Scoreboard fields.
     /// Missing values are initialized to `0` without overwriting existing data.
     func syncScoreboardFields() {
@@ -404,7 +376,7 @@ class LifeScoreboardViewModel: ObservableObject {
         // Ensure Life Scoreboard fields exist before loading data
         syncScoreboardFields()
 
-        fetchScoreboardMembers { [weak self] fetched in
+        CloudKitManager.shared.fetchAllTeamMembers { [weak self] fetched in
             guard let self = self else { return }
             let newHash = self.computeMemberHash(for: fetched)
 

--- a/StudyGroupApp/SplashViewModel.swift
+++ b/StudyGroupApp/SplashViewModel.swift
@@ -14,10 +14,11 @@ class SplashViewModel: ObservableObject {
         }
     }
 
-    /// Adds a new member by creating paired Win and Scoreboard records then refreshes ``teamMembers``.
+    /// Adds a new member record and refreshes ``teamMembers``.
     func addMember(name: String, emoji: String = "🙂") {
-        CloudKitManager.shared.createTeamMemberRecords(for: name)
-        fetchMembersFromCloud()
+        CloudKitManager.shared.addTeamMember(name: name, emoji: emoji) { [weak self] _ in
+            self?.fetchMembersFromCloud()
+        }
     }
 
     /// Deletes the provided member record and refreshes the list.

--- a/StudyGroupApp/UserSelectorView.swift
+++ b/StudyGroupApp/UserSelectorView.swift
@@ -76,8 +76,11 @@ struct UserSelectorView: View {
                                     guard !trimmed.isEmpty, !userManager.userList.contains(trimmed) else { return }
                                     userManager.addUser(trimmed)
                                     CloudKitManager.shared.createScoreRecord(for: trimmed)
-                                    CloudKitManager.shared.createTeamMemberRecords(for: trimmed)
-                                    viewModel.fetchMembersFromCloud()
+                                    // Use CloudKitManager's helper so the new member
+                                    // inherits existing production goals.
+                                    CloudKitManager.shared.addTeamMember(name: trimmed) { _ in
+                                        viewModel.fetchMembersFromCloud()
+                                    }
                                     newUserName = ""
                                 })
                                 Button("Cancel", role: .cancel) { }


### PR DESCRIPTION
## Summary
- revert merge commit that added sandboxed scoreboard records

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685a057329f0832291f63ae2148ecb5a