### PR TITLE
Sync Life Scoreboard with TeamMember records

### DIFF
--- a/StudyGroupApp/LifeScoreboardViewModel.swift
+++ b/StudyGroupApp/LifeScoreboardViewModel.swift
@@ -4,7 +4,6 @@ import Foundation
 class LifeScoreboardViewModel: ObservableObject {
     /// CloudKit container shared with WinTheDay
     private let container = CloudKitManager.container
-    private let recordType = "ScoreRecord"
 
     /// All team members fetched from CloudKit
     @Published var teamMembers: [TeamMember] = []
@@ -278,7 +277,7 @@ class LifeScoreboardViewModel: ObservableObject {
         saveLocal()
 
         let container = CloudKitManager.container
-        let recordID = CKRecord.ID(recordName: "score-\(entry.name)")
+        let recordID = CKRecord.ID(recordName: "member-\(entry.name)")
 
         container.publicCloudDatabase.fetch(withRecordID: recordID) { existingRecord, _ in
             if let record = existingRecord {
@@ -299,21 +298,6 @@ class LifeScoreboardViewModel: ObservableObject {
         }
     }
 
-    func createTestScoreRecord() {
-        let record = CKRecord(recordType: recordType)
-        record["name"] = "D.J." as CKRecordValue
-        record["score"] = 5 as CKRecordValue
-        record["pending"] = 2 as CKRecordValue
-        record["projected"] = 100.0 as CKRecordValue
-
-        container.publicCloudDatabase.save(record) { _, error in
-            if let error = error {
-                print("❌ Error saving test record: \(error.localizedDescription)")
-            } else {
-                print("✅ Test record saved to CloudKit")
-            }
-        }
-    }
     /// Ensures all `TeamMember` records contain Life Scoreboard fields.
     /// Missing values are initialized to `0` without overwriting existing data.
     func syncScoreboardFields() {

--- a/StudyGroupApp/UserSelectorView.swift
+++ b/StudyGroupApp/UserSelectorView.swift
@@ -75,7 +75,6 @@ struct UserSelectorView: View {
                                     let trimmed = newUserName.trimmingCharacters(in: .whitespacesAndNewlines)
                                     guard !trimmed.isEmpty, !userManager.userList.contains(trimmed) else { return }
                                     userManager.addUser(trimmed)
-                                    CloudKitManager.shared.createScoreRecord(for: trimmed)
                                     // Use CloudKitManager's helper so the new member
                                     // inherits existing production goals.
                                     CloudKitManager.shared.addTeamMember(name: trimmed) { _ in
@@ -104,7 +103,6 @@ struct UserSelectorView: View {
         for index in offsets {
             let member = viewModel.teamMembers[index]
             userManager.deleteUser(member.name)
-            CloudKitManager.shared.deleteScoreRecord(for: member.name)
             CloudKitManager.shared.deleteByName(member.name) { _ in
                 viewModel.fetchMembersFromCloud()
             }


### PR DESCRIPTION
## Summary
- remove ScoreRecord helpers and references
- save Life Scoreboard scores to TeamMember records
- adjust CloudKitManager.fetchScores to read TeamMember fields
- stop creating/deleting ScoreRecord objects when managing users

## Testing
- `swift --version`
- `swiftc -typecheck CloudKitManager.swift StudyGroupApp/*.swift` *(fails: no such module 'CloudKit')*

------
https://chatgpt.com/codex/tasks/task_e_685b4fbca15c83229e428729bfc67545