### PR TITLE
Fix CloudKit modifyRecords deprecation

### DIFF
--- a/Outcast/WinTheDayViewModel.swift
+++ b/Outcast/WinTheDayViewModel.swift
@@ -97,12 +97,13 @@ class WinTheDayViewModel: ObservableObject {
         let records = membersToUpload.compactMap { $0.toCKRecord() }
 
         let operation = CKModifyRecordsOperation(recordsToSave: records, recordIDsToDelete: nil)
-        operation.modifyRecordsCompletionBlock = { saved, _, error in
+        operation.modifyRecordsResultBlock = { result in
             DispatchQueue.main.async {
-                if let error = error {
+                switch result {
+                case .success(let (saved, _)):
+                    print("✅ Uploaded \(saved.count) members to CloudKit.")
+                case .failure(let error):
                     print("❌ Upload failed: \(error.localizedDescription)")
-                } else {
-                    print("✅ Uploaded \(saved?.count ?? 0) members to CloudKit.")
                 }
             }
         }

--- a/StudyGroupApp/LifeScoreboardViewModel.swift
+++ b/StudyGroupApp/LifeScoreboardViewModel.swift
@@ -420,11 +420,12 @@ class LifeScoreboardViewModel: ObservableObject {
                 // Step 2: Delete unnamed records
                 let deleteOp = CKModifyRecordsOperation(recordsToSave: nil, recordIDsToDelete: recordsToDelete)
                 deleteOp.savePolicy = .allKeys
-                deleteOp.modifyRecordsCompletionBlock = { _, deleted, error in
-                    if let error = error {
+                deleteOp.modifyRecordsResultBlock = { result in
+                    switch result {
+                    case .success(let (_, deleted)):
+                        print("🧹 Deleted \(deleted.count) unnamed TeamMember records")
+                    case .failure(let error):
                         print("❌ Failed to delete unnamed records: \(error)")
-                    } else {
-                        print("🧹 Deleted \(deleted?.count ?? 0) unnamed TeamMember records")
                     }
                 }
 
@@ -444,14 +445,15 @@ class LifeScoreboardViewModel: ObservableObject {
 
                 let saveOp = CKModifyRecordsOperation(recordsToSave: recordsToSave, recordIDsToDelete: nil)
                 saveOp.savePolicy = .allKeys
-                saveOp.modifyRecordsCompletionBlock = { saved, _, error in
-                    if let error = error {
-                        print("❌ Failed to save TeamMember records: \(error)")
-                    } else {
-                        print("✅ Synced \(saved?.count ?? 0) TeamMember records to CloudKit")
+                saveOp.modifyRecordsResultBlock = { result in
+                    switch result {
+                    case .success(let (saved, _)):
+                        print("✅ Synced \(saved.count) TeamMember records to CloudKit")
                         DispatchQueue.main.async {
                             self.fetchTeamMembersFromCloud()
                         }
+                    case .failure(let error):
+                        print("❌ Failed to save TeamMember records: \(error)")
                     }
                 }
 


### PR DESCRIPTION
## Summary
- update CloudKit calls to `modifyRecordsResultBlock`

## Testing
- `swiftc --version`
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_685b5b329afc8322bf4face5976d8cb0