### PR TITLE
Fix emoji updates without resetting scoreboard

### DIFF
--- a/CloudKitManager.swift
+++ b/CloudKitManager.swift
@@ -331,6 +331,19 @@ class CloudKitManager: ObservableObject {
         }
     }
 
+    /// Updates only the emoji for the given member name, preserving all other fields.
+    func updateEmoji(for name: String, emoji: String) {
+        fetchFiltered(byUserName: name) { members in
+            guard var member = members.first else {
+                print("❌ No matching TeamMember found for \(name)")
+                return
+            }
+
+            member.emoji = emoji
+            self.save(member) { _ in }
+        }
+    }
+
 
     func fetchScores(for names: [String], completion: @escaping ([String: (score: Int, pending: Int, projected: Double)]) -> Void) {
         print("\u{1F50D} Starting fetchScores() for names: \(names)")

--- a/StudyGroupApp/WinTheDayView.swift
+++ b/StudyGroupApp/WinTheDayView.swift
@@ -396,7 +396,7 @@ private var emojiGrid: some View {
                     if let id = emojiEditingID,
                        let index = viewModel.teamMembers.firstIndex(where: { $0.id == id }) {
                         viewModel.teamMembers[index].emoji = emoji
-                        viewModel.saveMember(viewModel.teamMembers[index])
+                        viewModel.updateEmoji(for: viewModel.teamMembers[index])
                         viewModel.teamMembers = viewModel.teamMembers.map { $0 }
                     }
                     emojiPickerVisible = false

--- a/StudyGroupApp/WinTheDayViewModel.swift
+++ b/StudyGroupApp/WinTheDayViewModel.swift
@@ -290,6 +290,12 @@ class WinTheDayViewModel: ObservableObject {
         }
         saveLocal()
     }
+
+    /// Updates a member's emoji using CloudKit while preserving scoreboard data.
+    func updateEmoji(for member: TeamMember) {
+        CloudKitManager.shared.updateEmoji(for: member.name, emoji: member.emoji)
+        saveLocal()
+    }
     /// Reorders team members by current production (quotes + sales) and updates
     /// their persisted `sortIndex`. This mirrors the stable ordering logic used
     /// in LifeScoreboardViewModel.


### PR DESCRIPTION
## Summary
- add updateEmoji() in `CloudKitManager` to safely update emoji
- call new method from WinTheDay UI via view model
- persist emoji changes with `updateEmoji(for:)` in `WinTheDayViewModel`

## Testing
- `swift --version`
- `swift build` *(fails: Package.swift missing)*

------
https://chatgpt.com/codex/tasks/task_e_685b6011c6848322a50ccc2fdc317661