### PR TITLE
Restore emoji update patch

### DIFF
--- a/CloudKitManager.swift
+++ b/CloudKitManager.swift
@@ -369,6 +369,22 @@ class CloudKitManager: ObservableObject {
         database.add(operation)
     }
 
+    /// Updates only the emoji value for the given member without overwriting
+    /// their production stats.
+    func updateEmoji(for name: String, emoji: String, completion: @escaping (Bool) -> Void = { _ in }) {
+        let id = memberID(for: name)
+        database.fetch(withRecordID: id) { record, error in
+            guard let record = record, error == nil else {
+                DispatchQueue.main.async { completion(false) }
+                return
+            }
+            record["emoji"] = emoji as CKRecordValue
+            self.database.save(record) { _, error in
+                DispatchQueue.main.async { completion(error == nil) }
+            }
+        }
+    }
+
     // MARK: - Card Order
     func fetchCardOrder(for user: String, completion: @escaping ([String]?) -> Void) {
         print("\u{1F50D} Starting fetchCardOrder() for user: \(user)")

--- a/StudyGroupApp/WinTheDayView.swift
+++ b/StudyGroupApp/WinTheDayView.swift
@@ -396,7 +396,7 @@ private var emojiGrid: some View {
                     if let id = emojiEditingID,
                        let index = viewModel.teamMembers.firstIndex(where: { $0.id == id }) {
                         viewModel.teamMembers[index].emoji = emoji
-                        viewModel.saveMember(viewModel.teamMembers[index])
+                        viewModel.updateEmoji(for: viewModel.teamMembers[index])
                         viewModel.teamMembers = viewModel.teamMembers.map { $0 }
                     }
                     emojiPickerVisible = false

--- a/StudyGroupApp/WinTheDayViewModel.swift
+++ b/StudyGroupApp/WinTheDayViewModel.swift
@@ -290,6 +290,14 @@ class WinTheDayViewModel: ObservableObject {
         }
         saveLocal()
     }
+
+    /// Updates only the emoji for the provided member in CloudKit.
+    func updateEmoji(for member: TeamMember, completion: ((Bool) -> Void)? = nil) {
+        CloudKitManager.shared.updateEmoji(for: member.name, emoji: member.emoji) { success in
+            completion?(success)
+        }
+        saveLocal()
+    }
     /// Reorders team members by current production (quotes + sales) and updates
     /// their persisted `sortIndex`. This mirrors the stable ordering logic used
     /// in LifeScoreboardViewModel.


### PR DESCRIPTION
## Summary
- add `updateEmoji` to `CloudKitManager`
- expose `updateEmoji` helper in `WinTheDayViewModel`
- ensure emoji picker uses the new update method so scores persist

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685ca137a0488322a3157c0a2ce6d2e0