### PR TITLE
Add sandbox goal tile preview

### DIFF
--- a/StudyGroupApp/GoalTilePreview.swift
+++ b/StudyGroupApp/GoalTilePreview.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+
+// MARK: - Model
+
+struct Goal: Identifiable {
+    let id = UUID()
+    let title: String
+    let percent: Int
+}
+
+struct Person: Identifiable {
+    let id = UUID()
+    let name: String
+    let emoji: String
+    let achieved: Int
+    let goals: [Goal]
+}
+
+// MARK: - Mock Data
+
+let mockPeople: [Person] = [
+    Person(name: "Ron", emoji: "🧔🏻", achieved: 0, goals: [
+        Goal(title: "Auto 115", percent: 0),
+        Goal(title: "Fire 65", percent: 0),
+        Goal(title: "Life 20", percent: 0)
+    ]),
+    Person(name: "Deanna", emoji: "👩🏽‍💼", achieved: 27, goals: [
+        Goal(title: "Auto 75", percent: 48),
+        Goal(title: "Fire 60", percent: 20),
+        Goal(title: "Life 25", percent: 24),
+        Goal(title: "License x2", percent: 50),
+        Goal(title: "Workout", percent: 17)
+    ]),
+    Person(name: "D.J.", emoji: "👨🏽‍💼", achieved: 18, goals: [
+        Goal(title: "Auto +75", percent: 18),
+        Goal(title: "Fire +75", percent: 40),
+        Goal(title: "Life Issued", percent: 8),
+        Goal(title: "Appointments", percent: 4)
+    ]),
+    Person(name: "Dimitri", emoji: "🧔🏽", achieved: 25, goals: [
+        Goal(title: "Life Issued 75", percent: 77),
+        Goal(title: "Health Issued 3", percent: 0),
+        Goal(title: "Google 12", percent: 42),
+        Goal(title: "Lose 15 lbs", percent: 33)
+    ])
+]
+
+// MARK: - Tile View
+
+struct PersonTileView: View {
+    let person: Person
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Header
+            HStack {
+                Text("\(person.emoji) \(person.name)")
+                    .font(.headline)
+                Spacer()
+                Text("\(person.achieved)% Achieved")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+            
+            // Goals
+            ForEach(person.goals) { goal in
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text(goal.title)
+                        Spacer()
+                        Text("\(goal.percent)%")
+                            .foregroundColor(.secondary)
+                    }
+                    ProgressView(value: Float(goal.percent), total: 100)
+                        .tint(progressColor(for: goal.percent))
+                }
+            }
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 16).fill(Color(.systemBackground)).shadow(radius: 2))
+    }
+    
+    func progressColor(for percent: Int) -> Color {
+        if percent == 0 {
+            return .gray
+        } else if percent < 50 {
+            return .yellow
+        } else {
+            return .green
+        }
+    }
+}
+
+// MARK: - Sandbox Preview
+
+struct GoalTilePreview: View {
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                ForEach(mockPeople) { person in
+                    PersonTileView(person: person)
+                        .padding(.horizontal)
+                }
+            }
+            .padding(.vertical)
+        }
+        .background(Color(.secondarySystemBackground).ignoresSafeArea())
+    }
+}
+
+struct GoalTilePreview_Previews: PreviewProvider {
+    static var previews: some View {
+        GoalTilePreview()
+    }
+}
+

--- a/StudyGroupApp/StudyGroupApp.xcodeproj/project.pbxproj
+++ b/StudyGroupApp/StudyGroupApp.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		B6C560C62DEFCC0E00F64256 /* ActivityEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C560C52DEFCC0E00F64256 /* ActivityEditorView.swift */; };
 		B6CB206A2DE3D90A00CE7A18 /* LaunchScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6CB20692DE3D90A00CE7A18 /* LaunchScreenView.swift */; };
 		F24CB4DF149A4B09974A1B6C /* CodexNotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12B75D2389F8474FB89FF01B /* CodexNotes.swift */; };
+                D1A1FCEE2E7515F700B1C002 /* GoalTilePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A1FCEE2E7515F700B1C001 /* GoalTilePreview.swift */; };
 		FEED00012DEFCAFE00000002 /* SplashViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED00002DEFCAFE00000002 /* SplashViewModel.swift */; };
 /* End PBXBuildFile section */
 
@@ -55,6 +56,7 @@
 		B6CB20682DE3B35B00CE7A18 /* StudyGroupApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StudyGroupApp.entitlements; sourceTree = "<group>"; };
 		B6CB20692DE3D90A00CE7A18 /* LaunchScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchScreenView.swift; sourceTree = "<group>"; };
 		FEED00002DEFCAFE00000002 /* SplashViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewModel.swift; sourceTree = "<group>"; };
+                D1A1FCEE2E7515F700B1C001 /* GoalTilePreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalTilePreview.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -96,6 +98,7 @@
 				B653C53C2DE2403E001B905F /* WinTheDayView.swift */,
 				12B75D2389F8474FB89FF01B /* CodexNotes.swift */,
 				2EADEA15A39A4A2E911AD6C8 /* TempScoreRowShowcase.swift */,
+                                D1A1FCEE2E7515F700B1C001 /* GoalTilePreview.swift */,
 			);
 			sourceTree = "<group>";
 		};
@@ -206,6 +209,7 @@
 				B6CB206A2DE3D90A00CE7A18 /* LaunchScreenView.swift in Sources */,
 				F24CB4DF149A4B09974A1B6C /* CodexNotes.swift in Sources */,
 				4DC20FA6D8614B33B40C5DB3 /* TempScoreRowShowcase.swift in Sources */,
+                                D1A1FCEE2E7515F700B1C002 /* GoalTilePreview.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Summary
- create `GoalTilePreview.swift` to preview goal tiles for four people
- register new preview file in Xcode project

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865e0e7baa0832299237f33f8080cad