### PR TITLE
Fix CardView uses a binding member

### DIFF
--- a/StudyGroupApp/TwelveWeekCardView.swift
+++ b/StudyGroupApp/TwelveWeekCardView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct CardView: View {
+    @Binding var member: TwelveWeekMember
     @State private var editingGoal: GoalProgress?
     @State private var isEditingGoals = false
     @Environment(\.dismiss) private var dismiss


### PR DESCRIPTION
## Summary
- expose `member` as a `@Binding` inside `CardView` so the view can edit team data

## Testing
- `swiftc StudyGroupApp/TwelveWeekCardView.swift -o /tmp/test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_687852b0da6c83229062a5eebe19fbe9