### PR TITLE
Fix CardView preview for iOS 15

### DIFF
--- a/StudyGroupApp/TwelveWeekCardView.swift
+++ b/StudyGroupApp/TwelveWeekCardView.swift
@@ -211,14 +211,26 @@ private func onTimeTargetProgress() -> Double {
     return percentElapsed
 }
 
-#Preview {
-    StatefulPreviewWrapper(TwelveWeekMember(name: "Demo", goals: [
-        .init(title: "Auto", percent: 0.5),
-        .init(title: "Fire", percent: 0.6),
-        .init(title: "Life", percent: 0.4),
-        .init(title: "Training", percent: 0.7)
-    ])) { $member in
-        CardView(member: $member)
-            .preferredColorScheme(.dark)
+struct TwelveWeekCardView_Previews: PreviewProvider {
+    struct PreviewWrapper: View {
+        @State private var sample = TwelveWeekMember(
+            name: "Demo",
+            goals: [
+                GoalProgress(title: "Auto", percent: 0.5),
+                GoalProgress(title: "Fire", percent: 0.6),
+                GoalProgress(title: "Life", percent: 0.4),
+                GoalProgress(title: "Training", percent: 0.7)
+            ]
+        )
+
+        var body: some View {
+            CardView(member: $sample)
+                .preferredColorScheme(.dark)
+                .padding()
+        }
+    }
+
+    static var previews: some View {
+        PreviewWrapper()
     }
 }


### PR DESCRIPTION
## Summary
- replace the `#Preview` macro in `TwelveWeekCardView.swift` with a standard `PreviewProvider`
- use a local `@State` sample model for the preview binding

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68799ace4f708322bebf1009570ce4ac