### PR TITLE
Enable Codable for GoalProgress

### DIFF
--- a/StudyGroupApp/TeamModels.swift
+++ b/StudyGroupApp/TeamModels.swift
@@ -1,10 +1,16 @@
 import Foundation
 
-struct GoalProgress: Identifiable {
-    let id = UUID()
+struct GoalProgress: Identifiable, Codable, Equatable {
+    /// Stable identifier for each goal. Defaults to a new UUID when not provided.
+    let id: UUID
     var title: String
     var percent: Double
-}
 
-extension GoalProgress: Equatable {}
+    /// Creates a new `GoalProgress` optionally overriding the generated `id`.
+    init(id: UUID = UUID(), title: String, percent: Double) {
+        self.id = id
+        self.title = title
+        self.percent = percent
+    }
+}
 


### PR DESCRIPTION
## Summary
- make `GoalProgress` conform to `Codable` and `Equatable`
- add initializer that allows an optional id

## Testing
- `swiftc StudyGroupApp/TeamModels.swift -o /tmp/test && echo "compiled"`

------
https://chatgpt.com/codex/tasks/task_e_687d85bcb184832287883491c46c16cc