### PR TITLE
Switch to CloudKitManager container

### DIFF
--- a/StudyGroupApp/TwelveWeekYearViewModel.swift
+++ b/StudyGroupApp/TwelveWeekYearViewModel.swift
@@ -4,7 +4,8 @@ import CloudKit
 class TwelveWeekYearViewModel: ObservableObject {
     @Published var members: [TwelveWeekMember] = []
 
-    private let container = CKContainer.default()
+    /// Shared CloudKit container used across the app.
+    private let container = CloudKitManager.container
     private let defaultsKey = "TwelveWeekMembers"
     private var lastFetchHash: Int?
 


### PR DESCRIPTION
## Summary
- use `CloudKitManager.container` in `TwelveWeekYearViewModel`

## Testing
- `swiftc StudyGroupApp/StudyGroupApp/TwelveWeekYearViewModel.swift -o /tmp/test` *(fails: no such module 'CloudKit')*

------
https://chatgpt.com/codex/tasks/task_e_687ef722c7b483229aa0a884c97e44d6