### PR TITLE
Handle TWY record updates

### DIFF
--- a/StudyGroupApp/TwelveWeekMember.swift
+++ b/StudyGroupApp/TwelveWeekMember.swift
@@ -45,9 +45,15 @@ struct TwelveWeekMember: Identifiable, Codable {
     }
 
     /// CloudKit record representation of this model.
-    var record: CKRecord {
-        let recordID = CKRecord.ID(recordName: "twy-\(name)")
-        let record = CKRecord(recordType: Self.recordType, recordID: recordID)
+    var record: CKRecord { toRecord() }
+
+    /// Returns a ``CKRecord`` for this instance, optionally updating an existing
+    /// record.
+    func toRecord(existing: CKRecord? = nil) -> CKRecord {
+        let record = existing ?? CKRecord(
+            recordType: Self.recordType,
+            recordID: CKRecord.ID(recordName: "twy-\(name)")
+        )
         record["name"] = name as CKRecordValue
         if let data = try? JSONEncoder().encode(goals) {
             record["goals"] = data as CKRecordValue


### PR DESCRIPTION
## Summary
- add `toRecord(existing:)` helper on `TwelveWeekMember`
- update `saveTwelveWeekMember` to query for existing records and use a modify operation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880416477e083228b2ffa2ab0320b0a