### PR TITLE
Fix duplicate creation in updateLocalEntries

### DIFF
--- a/StudyGroupApp/TwelveWeekYearViewModel.swift
+++ b/StudyGroupApp/TwelveWeekYearViewModel.swift
@@ -87,7 +87,6 @@ class TwelveWeekYearViewModel: ObservableObject {
         for name in names where !members.contains(where: { $0.name == name }) {
             let newMember = TwelveWeekMember(name: name, goals: [])
             members.append(newMember)
-            saveMember(newMember)
         }
 
         saveLocalMembers()


### PR DESCRIPTION
## Summary
- remove `saveMember` call when adding a missing local member

## Testing
- `swift --version`
- `swift package describe` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688042c358ec8322a9e1333f99c8c695