### PR TITLE
Fix CloudKit TWY query

### DIFF
--- a/CloudKitManager.swift
+++ b/CloudKitManager.swift
@@ -587,11 +587,20 @@ class CloudKitManager: ObservableObject {
         }
     }
 
-    /// Fetches all `TwelveWeekMember` records from CloudKit.
-    static func fetchTwelveWeekMembers(completion: @escaping ([TwelveWeekMember]) -> Void) {
+    /// Fetches `TwelveWeekMember` records from CloudKit.
+    /// - Parameter names: Optional list of member names to filter by. Pass
+    ///   `nil` or an empty array to fetch all records.
+    static func fetchTwelveWeekMembers(matching names: [String]? = nil,
+                                       completion: @escaping ([TwelveWeekMember]) -> Void) {
         print("\u{1F50D} Starting fetchTwelveWeekMembers()")
 
-        let query = CKQuery(recordType: TwelveWeekMember.recordType, predicate: NSPredicate(value: true))
+        let predicate: NSPredicate
+        if let names = names, !names.isEmpty {
+            predicate = NSPredicate(format: "name IN %@", names)
+        } else {
+            predicate = NSPredicate(value: true)
+        }
+        let query = CKQuery(recordType: TwelveWeekMember.recordType, predicate: predicate)
 
         CloudKitManager.container.publicCloudDatabase.fetch(withQuery: query, inZoneWith: nil, desiredKeys: nil, resultsLimit: CKQueryOperation.maximumResults) { result in
             switch result {

--- a/StudyGroupApp/TwelveWeekYearViewModel.swift
+++ b/StudyGroupApp/TwelveWeekYearViewModel.swift
@@ -47,7 +47,7 @@ class TwelveWeekYearViewModel: ObservableObject {
         let names = UserManager.shared.userList
         updateLocalEntries(names: names)
 
-        CloudKitManager.fetchTwelveWeekMembers { [weak self] fetched in
+        CloudKitManager.fetchTwelveWeekMembers(matching: names) { [weak self] fetched in
             guard let self = self else { return }
             let newHash = self.computeHash(for: fetched)
             DispatchQueue.main.async {


### PR DESCRIPTION
## Summary
- adjust `fetchTwelveWeekMembers` to use only queryable fields
- pass the active user list when fetching TWY members

## Testing
- `swift build` *(fails: no Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68804756797883229014893885124afc