### PR TITLE
Add completion handler for TWY save

### DIFF
--- a/CloudKitManager.swift
+++ b/CloudKitManager.swift
@@ -535,7 +535,8 @@ class CloudKitManager: ObservableObject {
     // MARK: - Twelve Week Year
 
     /// Saves a `TwelveWeekMember` record to CloudKit.
-    static func saveTwelveWeekMember(_ member: TwelveWeekMember) {
+    static func saveTwelveWeekMember(_ member: TwelveWeekMember,
+                                     completion: @escaping (Result<CKRecord.ID, Error>) -> Void = { _ in }) {
         let predicate = NSPredicate(format: "name == %@", member.name)
         let query = CKQuery(recordType: TwelveWeekMember.recordType, predicate: predicate)
         let operation = CKQueryOperation(query: query)
@@ -564,8 +565,10 @@ class CloudKitManager: ObservableObject {
                         switch modifyResult {
                         case .failure(let error):
                             print("❌ Error saving TWY member \(record.recordID.recordName): \(error.localizedDescription)")
+                            completion(.failure(error))
                         case .success:
                             print("✅ Successfully saved TWY member: \(member.name)")
+                            completion(.success(record.recordID))
                         }
                     }
                 }

--- a/StudyGroupApp/TwelveWeekYearViewModel.swift
+++ b/StudyGroupApp/TwelveWeekYearViewModel.swift
@@ -61,7 +61,14 @@ class TwelveWeekYearViewModel: ObservableObject {
     }
 
     func saveMember(_ member: TwelveWeekMember) {
-        CloudKitManager.saveTwelveWeekMember(member)
+        CloudKitManager.saveTwelveWeekMember(member) { result in
+            switch result {
+            case .success:
+                print("✅ TWY member saved: \(member.name)")
+            case .failure(let error):
+                print("❌ Failed to save TWY member \(member.name): \(error.localizedDescription)")
+            }
+        }
         if let idx = members.firstIndex(where: { $0.name == member.name }) {
             members[idx] = member
         } else {

--- a/StudyGroupApp/UserManager.swift
+++ b/StudyGroupApp/UserManager.swift
@@ -66,7 +66,7 @@ class UserManager: ObservableObject {
             )
             CloudKitManager.saveCard(defaultCard)
             let twy = TwelveWeekMember(name: name, goals: [])
-            CloudKitManager.saveTwelveWeekMember(twy)
+            CloudKitManager.saveTwelveWeekMember(twy) { _ in }
             self?.fetchUsersFromCloud()
         }
     }


### PR DESCRIPTION
## Summary
- add a completion closure to `CloudKitManager.saveTwelveWeekMember`
- log the result when saving from `TwelveWeekYearViewModel`
- update `UserManager` to use new API

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68819323631c83229e81d8a604ccfc0f