### PR TITLE
Add default TeamMember on user creation

### DIFF
--- a/StudyGroupApp/UserManager.swift
+++ b/StudyGroupApp/UserManager.swift
@@ -56,6 +56,10 @@ class UserManager: ObservableObject {
     func addUser(_ name: String) {
         guard !userList.contains(name) else { return }
         CloudKitManager.saveUser(name) { [weak self] in
+            // Create a TeamMember record with default production goals
+            let member = TeamMember(name: name)
+            CloudKitManager.shared.save(member) { _ in }
+
             // Create a default Win the Day card so the record type exists
             let defaultCard = Card(
                 id: "card-\(name)",

--- a/StudyGroupApp/UserSelectorView.swift
+++ b/StudyGroupApp/UserSelectorView.swift
@@ -75,11 +75,7 @@ struct UserSelectorView: View {
                                     let trimmed = newUserName.trimmingCharacters(in: .whitespacesAndNewlines)
                                     guard !trimmed.isEmpty, !userManager.userList.contains(trimmed) else { return }
                                     userManager.addUser(trimmed)
-                                    // Use CloudKitManager's helper so the new member
-                                    // inherits existing production goals.
-                                    CloudKitManager.shared.addTeamMember(name: trimmed) { _ in
-                                        viewModel.fetchMembersFromCloud()
-                                    }
+                                    viewModel.fetchMembersFromCloud()
                                     newUserName = ""
                                 })
                                 Button("Cancel", role: .cancel) { }


### PR DESCRIPTION
## Summary
- create a default `TeamMember` after saving a new user
- fetch Cloud data in user selector without duplicating the member save

## Testing
- `swift build` *(fails: "Could not find Package.swift" – project is not a Swift package)*

------
https://chatgpt.com/codex/tasks/task_e_68857baa329c8322b3caebbccfbe2a80