### PR TITLE
Fix duplicate card fetch in WinTheDayViewModel

### DIFF
--- a/StudyGroupApp/WinTheDayViewModel.swift
+++ b/StudyGroupApp/WinTheDayViewModel.swift
@@ -16,7 +16,6 @@ class WinTheDayViewModel: ObservableObject {
         self.teamData = stored
         self.cards = loadCardsFromDevice()
         self.displayedCards = self.cards
-        fetchCardsFromCloud()
         let names = Self.loadLocalGoalNames()
         self.goalNames = names
         self.lastGoalHash = Self.computeGoalHash(for: names)


### PR DESCRIPTION
## Summary
- avoid duplicate card fetching during model initialization

## Testing
- `swiftc -frontend -typecheck StudyGroupApp/WinTheDayViewModel.swift`

------
https://chatgpt.com/codex/tasks/task_e_688589f97c948322a81c6d4023e16e97