### PR TITLE
Ensure teamMembers align with user list

### DIFF
--- a/StudyGroupApp/WinTheDayViewModel.swift
+++ b/StudyGroupApp/WinTheDayViewModel.swift
@@ -171,6 +171,11 @@ class WinTheDayViewModel: ObservableObject {
                     self.saveLocal()
                 }
 
+                // Ensure local entries mirror the latest user list so any
+                // missing members exist before merging card data.
+                let allNames = UserManager.shared.userList
+                self.updateLocalEntries(names: allNames)
+
                 CloudKitManager.fetchCards { cards in
                     DispatchQueue.main.async {
                         var merged = self.cards


### PR DESCRIPTION
## Summary
- refresh local team member entries using the current user list after loading from CloudKit

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68858b5030888322905ecea0293c5ff3