### PR TITLE
Implement card order syncing

### DIFF
--- a/StudyGroupApp/WinTheDayView.swift
+++ b/StudyGroupApp/WinTheDayView.swift
@@ -82,6 +82,7 @@ struct WinTheDayView: View {
             viewModel.fetchMembersFromCloud()
             viewModel.fetchGoalNamesFromCloud()
             viewModel.ensureCardsForAllUsers(userManager.userList)
+            viewModel.loadCardOrderFromCloud(for: userManager.currentUser)
             shimmerPosition = -1.0
             withAnimation(Animation.linear(duration: 12).repeatForever(autoreverses: false)) {
                 shimmerPosition = 1.5
@@ -416,6 +417,7 @@ private func handleSaveAndReorder() {
     withAnimation {
         viewModel.reorderAfterSave()
     }
+    viewModel.saveCardOrderToCloud(for: userManager.currentUser)
 }
 
 


### PR DESCRIPTION
## Summary
- load card order from CloudKit in `WinTheDayView` on appear
- upload card order to CloudKit whenever cards reorder

## Testing
- `swift --version`
- `swiftc -typecheck StudyGroupApp/WinTheDayView.swift StudyGroupApp/WinTheDayViewModel.swift StudyGroupApp/UserManager.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68858c4b617c83229e7a314543b489f3