### PR TITLE
Reduce unneeded CloudKit fetches

### DIFF
--- a/StudyGroupApp/TwelveWeekYearView.swift
+++ b/StudyGroupApp/TwelveWeekYearView.swift
@@ -17,9 +17,6 @@ struct TwelveWeekYearView: View {
     var body: some View {
         buildMainView()
             .edgesIgnoringSafeArea(.all)
-        .onAppear {
-            viewModel.fetchMembersFromCloud()
-        }
         .onChange(of: userManager.userList) { _ in
             viewModel.fetchMembersFromCloud()
         }
@@ -86,6 +83,9 @@ struct TwelveWeekYearView: View {
                 .padding(.horizontal, 16)
                 .padding(.bottom, 16)
                 .scaleEffect(UIDevice.current.userInterfaceIdiom == .pad ? 0.75 : 1.0)
+            }
+            .refreshable {
+                viewModel.fetchMembersFromCloud()
             }
         }
         .fullScreenCover(item: $selectedMember) { member in

--- a/StudyGroupApp/WinTheDayView.swift
+++ b/StudyGroupApp/WinTheDayView.swift
@@ -79,7 +79,6 @@ struct WinTheDayView: View {
             }
         }
         .onAppear {
-            viewModel.fetchMembersFromCloud()
             viewModel.fetchGoalNamesFromCloud()
             viewModel.ensureCardsForAllUsers(userManager.userList)
             viewModel.loadCardOrderFromCloud(for: userManager.currentUser)


### PR DESCRIPTION
## Summary
- stop auto-syncing members when switching to the 12 Week Year tab
- only fetch `WinTheDay` members on pull-to-refresh or user list change

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6885922190808322bd56b35c33bd8da0