### PR TITLE
Add TeamMember field migration

### DIFF
--- a/StudyGroupApp/StudyGroupApp.swift
+++ b/StudyGroupApp/StudyGroupApp.swift
@@ -20,6 +20,7 @@ struct StudyGroupApp: App {
             }
             .animation(.easeInOut(duration: 0.4), value: isShowingLaunchScreen)
             .onAppear {
+                CloudKitManager.shared.migrateTeamMemberFieldsIfNeeded()
                 DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
                     withAnimation {
                         isShowingLaunchScreen = false


### PR DESCRIPTION
## Summary
- perform a CloudKit migration that fills missing TeamMember `actual`, `pending`, and `projected` fields with 0
- invoke the migration when the app launches

## Testing
- `swiftc -emit-module CloudKitManager.swift` *(fails: no such module 'CloudKit')*


------
https://chatgpt.com/codex/tasks/task_e_6885937157dc8322ac4aeb8aef245d45