### PR TITLE
Remove unused card loading helper

### DIFF
--- a/StudyGroupApp/WinTheDayViewModel.swift
+++ b/StudyGroupApp/WinTheDayViewModel.swift
@@ -85,27 +85,6 @@ class WinTheDayViewModel: ObservableObject {
 
     // MARK: - Card Sync Helpers
 
-
-    private func loadLocalCards() {
-        if let data = UserDefaults.standard.data(forKey: cardsStorageKey),
-           let cached = try? JSONDecoder().decode([Card].self, from: data) {
-            DispatchQueue.main.async {
-                self.cards = cached.sorted(by: { $0.orderIndex < $1.orderIndex })
-                self.displayedCards = self.cards
-                print("📦 Loaded cards from local cache.")
-            }
-        } else {
-            print("⚠️ No cached cards found.")
-        }
-    }
-
-    private func saveCardsToLocal() {
-        if let data = try? JSONEncoder().encode(cards) {
-            UserDefaults.standard.set(data, forKey: cardsStorageKey)
-            print("✅ Cards saved to local cache.")
-        }
-    }
-
     /// Convenience wrapper mirroring LifeScoreboardViewModel.fetchTeamMembersFromCloud
     /// for fetching the latest production values.
     func fetchScores() {


### PR DESCRIPTION
## Summary
- clean up `WinTheDayViewModel` by removing `loadLocalCards` and `saveCardsToLocal`
- cards are already loaded via `loadCardsFromDevice()` in `init`

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68865f0315048322af97f25a6dbb6398