### PR TITLE
Handle user change in WinTheDay

### DIFF
--- a/StudyGroupApp/WinTheDayView.swift
+++ b/StudyGroupApp/WinTheDayView.swift
@@ -87,7 +87,9 @@ struct WinTheDayView: View {
                 shimmerPosition = 1.5
             }
         }
-    .onChange(of: userManager.currentUser) { _ in }
+    .onChange(of: userManager.currentUser) { _ in
+        viewModel.loadCardOrderFromCloud(for: userManager.currentUser)
+    }
     .onChange(of: userManager.userList) { _ in
         if viewModel.isLoaded {
             viewModel.fetchMembersFromCloud()


### PR DESCRIPTION
## Summary
- trigger card order reload when the active user changes

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6886604772248322978f8737edef1585