### PR TITLE
Synchronize scoreboard fields during member fetch

### DIFF
--- a/StudyGroupApp/LifeScoreboardViewModel.swift
+++ b/StudyGroupApp/LifeScoreboardViewModel.swift
@@ -396,6 +396,9 @@ class LifeScoreboardViewModel: ObservableObject {
     func fetchTeamMembersFromCloud() {
         DispatchQueue.main.async {
             CloudKitManager.shared.migrateTeamMemberFieldsIfNeeded()
+            // Ensure all records contain scoreboard fields before fetching
+            // members so older entries gain the new fields.
+            self.syncScoreboardFields()
 
             CloudKitManager.shared.fetchAllTeamMembers { [weak self] fetched in
                 guard let self = self else { return }


### PR DESCRIPTION
## Summary
- ensure scoreboard fields are synced before fetching team members

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688661043b28832295c1028815b938f3