### PR TITLE
Fix daysInYear computed property

### DIFF
--- a/StudyGroupApp/LifeScoreboardViewModel.swift
+++ b/StudyGroupApp/LifeScoreboardViewModel.swift
@@ -563,7 +563,11 @@ extension LifeScoreboardViewModel {
     private var daysInYear: Int {
         let year = Calendar.current.component(.year, from: Date())
         let components = DateComponents(calendar: .current, year: year)
-        return Calendar.current.range(of: .day, in: .year, for: components.date!)?.count ?? 365
+        if let date = components.date,
+           let range = Calendar.current.range(of: .day, in: .year, for: date) {
+            return range.count
+        }
+        return 365
     }
 
     /// The current day of the year (1–365/366)


### PR DESCRIPTION
## Summary
- avoid force unwrap in `daysInYear` computed property
- guard for optional date and range before returning the count

## Testing
- `swiftc -parse StudyGroupApp/LifeScoreboardViewModel.swift`

------
https://chatgpt.com/codex/tasks/task_e_6886694d6358832297ac275584003f93