### PR TITLE
Inject shared models in MainTabView

### DIFF
--- a/StudyGroupApp/LifeScoreboardView.swift
+++ b/StudyGroupApp/LifeScoreboardView.swift
@@ -69,11 +69,15 @@ private struct IntStepperRow: View {
 }
 
 struct LifeScoreboardView: View {
-    @StateObject var viewModel = LifeScoreboardViewModel()
+    @StateObject var viewModel: LifeScoreboardViewModel
     @ObservedObject var userManager = UserManager.shared
     @State private var selectedEntry: LifeScoreboardViewModel.ScoreEntry?
     @State private var selectedRow: LifeScoreboardViewModel.ActivityRow?
     @State private var hasLoaded = false
+
+    init(viewModel: LifeScoreboardViewModel = LifeScoreboardViewModel()) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
 
     private func yearLabel() -> String {
         let month = Calendar.current.component(.month, from: Date())

--- a/StudyGroupApp/MainTabView.swift
+++ b/StudyGroupApp/MainTabView.swift
@@ -13,6 +13,9 @@ struct MainTabView: View {
     /// Shared WinTheDayViewModel passed from the splash screen so card state
     /// persists when entering the main tabs.
     @EnvironmentObject var viewModel: WinTheDayViewModel
+    @StateObject private var scoreboardVM = LifeScoreboardViewModel()
+    @StateObject private var twyVM = TwelveWeekYearViewModel()
+    @Environment(\.scenePhase) private var scenePhase
     init() {
         UITabBar.appearance().backgroundColor = UIColor.systemGray6
     }
@@ -24,16 +27,28 @@ struct MainTabView: View {
                     Text("Win the Day")
                 }
 
-            LifeScoreboardView(viewModel: LifeScoreboardViewModel())
+            LifeScoreboardView(viewModel: scoreboardVM)
                 .tabItem {
                     Image(systemName: "briefcase.fill")
                     Text("Scoreboard")
                 }
 
-            TwelveWeekYearView()
+            TwelveWeekYearView(viewModel: twyVM)
                 .tabItem {
                     Label("12 Week Year", systemImage: "calendar")
                 }
+        }
+        .onAppear {
+            viewModel.fetchMembersFromCloud()
+            scoreboardVM.fetchTeamMembersFromCloud()
+            twyVM.fetchMembersFromCloud()
+        }
+        .onChange(of: scenePhase) { phase in
+            if phase == .active {
+                viewModel.fetchMembersFromCloud()
+                scoreboardVM.fetchTeamMembersFromCloud()
+                twyVM.fetchMembersFromCloud()
+            }
         }
     }
 }

--- a/StudyGroupApp/TwelveWeekYearView.swift
+++ b/StudyGroupApp/TwelveWeekYearView.swift
@@ -1,9 +1,13 @@
 import SwiftUI
 
 struct TwelveWeekYearView: View {
-    @StateObject private var viewModel = TwelveWeekYearViewModel()
+    @StateObject var viewModel: TwelveWeekYearViewModel
     @ObservedObject private var userManager = UserManager.shared
     @State private var selectedMember: TwelveWeekMember? = nil
+
+    init(viewModel: TwelveWeekYearViewModel = TwelveWeekYearViewModel()) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
 
     var overallPercent: Double {
         guard !viewModel.members.isEmpty else { return 0 }


### PR DESCRIPTION
## Summary
- manage shared scoreboard and twelve week models in `MainTabView`
- allow `LifeScoreboardView` and `TwelveWeekYearView` to accept view models via init
- refresh data on appear and when scene becomes active

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6886bd00033083228f9819835ea92584