### PR TITLE
Lock 12 Week Year editing to current user

### DIFF
--- a/StudyGroupApp/TwelveWeekCardView.swift
+++ b/StudyGroupApp/TwelveWeekCardView.swift
@@ -6,8 +6,10 @@ struct CardView: View {
     @State private var isEditingGoals = false
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject private var viewModel: TwelveWeekYearViewModel
+    @ObservedObject private var userManager = UserManager.shared
 
     var body: some View {
+        let isCurrent = member.name == userManager.currentUser
         VStack(spacing: 24) {
             Text(member.name)
                 .font(.system(size: 40, weight: .heavy))
@@ -41,7 +43,7 @@ struct CardView: View {
                             }
                         }
 
-                        if isEditingGoals {
+                        if isEditingGoals && isCurrent {
                             Button(action: {
                                 member.goals.remove(at: index)
                             }) {
@@ -54,7 +56,7 @@ struct CardView: View {
                         }
                     }
                 }
-                if isEditingGoals {
+                if isEditingGoals && isCurrent {
                     Button(action: {
                         let newGoal = GoalProgress(title: "New Goal", percent: 0)
                         member.goals.append(newGoal)
@@ -88,13 +90,15 @@ struct CardView: View {
                 .environmentObject(viewModel)
         }
         .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: {
-                    isEditingGoals.toggle()
-                }) {
-                    Text(isEditingGoals ? "Save" : "Add Goal")
-                        .font(.headline)
-                        .foregroundColor(.white)
+            if isCurrent {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: {
+                        isEditingGoals.toggle()
+                    }) {
+                        Text(isEditingGoals ? "Save" : "Add Goal")
+                            .font(.headline)
+                            .foregroundColor(.white)
+                    }
                 }
             }
         }

--- a/StudyGroupApp/TwelveWeekYearView.swift
+++ b/StudyGroupApp/TwelveWeekYearView.swift
@@ -61,8 +61,9 @@ struct TwelveWeekYearView: View {
                                 }
                             )
                             HStack {
+                                let isCurrent = member.name == userManager.currentUser
                                 Text(member.name)
-                                    .font(.system(size: 26, weight: .medium))
+                                    .font(.system(size: 26, weight: isCurrent ? .bold : .medium))
                                     .foregroundColor(.white)
                                     .frame(width: 100, alignment: .leading)
                                     .padding(.trailing, 40)
@@ -81,7 +82,9 @@ struct TwelveWeekYearView: View {
                             .frame(maxWidth: .infinity)
                             .contentShape(Rectangle())
                             .onTapGesture {
-                                selectedMember = member
+                                if member.name == userManager.currentUser {
+                                    selectedMember = member
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- restrict opening 12 Week Year cards to the logged in user
- highlight the logged in user in the team list
- gate add/remove goal actions and edit toolbar to only appear for the logged in user

## Testing
- `swiftc -parse StudyGroupApp/TwelveWeekCardView.swift StudyGroupApp/TwelveWeekYearView.swift`

------
https://chatgpt.com/codex/tasks/task_e_6886c58073748322b4936f85e761cbac