### PR TITLE
Fix TwelveWeek toolbar ambiguity

### DIFF
--- a/StudyGroupApp/TwelveWeekCardView.swift
+++ b/StudyGroupApp/TwelveWeekCardView.swift
@@ -90,16 +90,16 @@ struct CardView: View {
                 GoalEditListView(member: $member)
                     .environmentObject(viewModel)
             }
-            .toolbar {
-                if isCurrent {
-                    ToolbarItem(placement: .navigationBarTrailing) {
-                        Button(action: {
-                            isEditingGoals.toggle()
-                        }) {
-                            Text(isEditingGoals ? "Save" : "Add Goal")
-                                .font(.headline)
-                                .foregroundColor(.white)
-                        }
+        }
+        .toolbar {
+            if isCurrent {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: {
+                        isEditingGoals.toggle()
+                    }) {
+                        Text(isEditingGoals ? "Save" : "Add Goal")
+                            .font(.headline)
+                            .foregroundColor(.white)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- move `.toolbar` outside the `.sheet` in `TwelveWeekCardView`

## Testing
- `swiftc StudyGroupApp/TwelveWeekCardView.swift -o /tmp/test.o` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6886cc2f5ea48322b8b7090b3cc6b524