### PR TITLE
Fix travel threshold color logic

### DIFF
--- a/StudyGroupApp/LifeScoreboardView.swift
+++ b/StudyGroupApp/LifeScoreboardView.swift
@@ -121,8 +121,8 @@ struct LifeScoreboardView: View {
 
                 // Team Members section
                 TeamMembersCard(
-                    honorThreshold: viewModel.onTime,
-                    travelThreshold: viewModel.travel
+                    honorThreshold: Double(viewModel.onTimeHonorTarget),
+                    travelThreshold: Double(viewModel.onTimeTravelTarget)
                 ) { entry, row in
                     selectedEntry = entry
                     selectedRow = row


### PR DESCRIPTION
## Summary
- fix team member row color thresholds to use the current on-time goals

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886d6beaaa88322954a7e5f3908e1fb