### PR TITLE
Fix dynamic color threshold

### DIFF
--- a/StudyGroupApp/LifeScoreboardView.swift
+++ b/StudyGroupApp/LifeScoreboardView.swift
@@ -254,13 +254,9 @@ private struct TeamMembersCard: View {
     var onSelect: (LifeScoreboardViewModel.ScoreEntry, LifeScoreboardViewModel.ActivityRow) -> Void
 
     private func color(for score: Double) -> Color {
-        let actualScore = score
-        let requiredForHonor = viewModel.onTime
-        let requiredForTravel = viewModel.travel
-
-        if actualScore >= requiredForTravel {
+        if score >= travelThreshold {
             return .green
-        } else if actualScore >= requiredForHonor {
+        } else if score >= honorThreshold {
             return .yellow
         } else {
             return .gray


### PR DESCRIPTION
## Summary
- use dynamic honor and travel thresholds when choosing progress color

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886d9807740832295f14a09ffc14547